### PR TITLE
feat/integrate transaction tracking

### DIFF
--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.spec.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.spec.tsx
@@ -79,7 +79,7 @@ vi.mock("./SendInterchainToken.state.ts", () => ({
       sendTokenAsync: mocks.sendTokenAsync,
       selectToChain: mocks.selectToChain,
       refetchBalances: mocks.refetchBalances,
-      addTransaction: mocks.addTransaction,
+      trackTransaction: mocks.addTransaction,
     } as Actions,
   ]),
 }));

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
@@ -129,7 +129,7 @@ export function useSendInterchainTokenState(props: {
       sendTokenAsync,
       selectToChain,
       refetchBalances,
-      addTransaction,
+      trackTransaction: addTransaction,
     },
   ] as const;
 }

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
@@ -2,7 +2,7 @@ import type { EVMChainConfig } from "@axelarjs/api";
 import { Button, FormControl, Label, Modal, TextInput } from "@axelarjs/ui";
 import { toast } from "@axelarjs/ui/toaster";
 import { invariant } from "@axelarjs/utils";
-import { useEffect, useMemo, type FC } from "react";
+import { useCallback, useEffect, useMemo, type FC } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 
 import { formatUnits, parseUnits } from "viem";
@@ -122,13 +122,27 @@ export const SendInterchainToken: FC<Props> = (props) => {
 
   useEffect(() => {
     if (state.txState.status === "submitted") {
-      actions.addTransaction({
+      actions.trackTransaction({
         status: "submitted",
         hash: state.txState.hash,
         chainId: props.sourceChain.chain_id,
       });
     }
   }, [actions, props.sourceChain, state.txState]);
+
+  const handleAllChainsExecuted = useCallback(async () => {
+    const txHash =
+      state.txState.status === "submitted" ? state.txState.hash : "0x";
+
+    await actions.refetchBalances();
+    resetForm();
+    actions.resetTxState();
+    actions.setIsModalOpen(false);
+    toast.success("Tokens sent successfully!", {
+      // use txHash as id to prevent duplicate toasts
+      id: `token-sent:${txHash}`,
+    });
+  }, [actions, resetForm, state.txState]);
 
   return (
     <Modal
@@ -242,13 +256,7 @@ export const SendInterchainToken: FC<Props> = (props) => {
           {state.txState.status === "submitted" && (
             <GMPTxStatusMonitor
               txHash={state.txState.hash}
-              onAllChainsExecuted={async () => {
-                await actions.refetchBalances();
-                resetForm();
-                actions.resetTxState();
-                actions.setIsModalOpen(false);
-                toast.success("Tokens sent successfully!");
-              }}
+              onAllChainsExecuted={handleAllChainsExecuted}
             />
           )}
           <Button

--- a/apps/maestro/src/server/routers/axelarscan/getEVMChainConfigs.ts
+++ b/apps/maestro/src/server/routers/axelarscan/getEVMChainConfigs.ts
@@ -1,7 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { DISABLED_CHAINS, IS_STAGING } from "~/config/app";
 import { publicProcedure } from "~/server/trpc";
 
 const evmChainConfigSchema = z.object({
@@ -70,10 +69,9 @@ export const getEVMChainConfigs = publicProcedure
   .output(z.array(evmChainConfigSchema))
   .query(async ({ ctx, input }) => {
     try {
-      const { evm } = await ctx.services.axelarscan.getChainConfigs({
-        disabledChains: DISABLED_CHAINS,
-        isStaging: IS_STAGING,
-      });
+      const chainsMap = await ctx.configs.evmChains();
+
+      const evm = Object.values(chainsMap).map((chain) => chain.info);
 
       return evm.filter(
         (chain) =>


### PR DESCRIPTION
* integrate tx tracking to remote token deployments
* prevent closing `Interchain Transfer` modal while tx is either `awaiting_approval` or `awaiting_spend`