### PR TITLE
refactor/transaction progress cards

### DIFF
--- a/apps/maestro/src/features/CanonicalTokenDeployment/hooks/useDeployAndRegisterRemoteCanonicalTokenMutation.ts
+++ b/apps/maestro/src/features/CanonicalTokenDeployment/hooks/useDeployAndRegisterRemoteCanonicalTokenMutation.ts
@@ -116,21 +116,21 @@ export function useDeployAndRegisterRemoteCanonicalTokenMutation(
     return [deployTxData, ...registerTxData];
   }, [input, tokenId, destinationChainNames, originalChainName]);
 
-  const totalGasFee = useMemo(
-    () =>
-      Maybe.of(input?.remoteDeploymentGasFees).mapOrUndefined(
-        reduce((a, b) => a + b, 0n)
-      ),
-    [input?.remoteDeploymentGasFees]
+  const totalGasFee = Maybe.of(input?.remoteDeploymentGasFees).mapOr(
+    0n,
+    reduce((a, b) => a + b, 0n)
   );
+
+  const isMutationReady =
+    multicallArgs.length > 0 &&
+    // enable if there are no remote chains or if there are remote chains and the total gas fee is greater than 0
+    (!destinationChainNames.length || totalGasFee > 0n);
 
   const prepareMulticall = usePrepareInterchainTokenFactoryMulticall({
     chainId,
     value: totalGasFee,
     args: [multicallArgs],
-    enabled:
-      multicallArgs.length > 0 &&
-      (totalGasFee === undefined || totalGasFee > 0n),
+    enabled: isMutationReady,
   });
 
   const multicall = useInterchainTokenFactoryMulticall(prepareMulticall.config);

--- a/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -93,6 +93,7 @@ export const Step3: FC = () => {
             status: "submitted",
             hash: tx.hash,
             chainId: sourceChain.chain_id,
+            txType: "INTERCHAIN_DEPLOYMENT",
           });
         },
         onTransactionError(txError) {
@@ -105,10 +106,10 @@ export const Step3: FC = () => {
       });
     },
     [
+      rootState.selectedChains.length,
+      state.totalGasFee,
       state.isEstimatingGasFees,
       state.hasGasFeesEstimationError,
-      state.remoteDeploymentGasFees,
-      state.evmChains,
       deployCanonicalTokenAsync,
       actions,
       sourceChain,

--- a/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -88,13 +88,14 @@ export const Step3: FC = () => {
             type: "deploying",
             txHash: tx.hash,
           });
-
-          addTransaction({
-            status: "submitted",
-            hash: tx.hash,
-            chainId: sourceChain.chain_id,
-            txType: "INTERCHAIN_DEPLOYMENT",
-          });
+          if (rootState.selectedChains.length > 0) {
+            addTransaction({
+              status: "submitted",
+              hash: tx.hash,
+              chainId: sourceChain.chain_id,
+              txType: "INTERCHAIN_DEPLOYMENT",
+            });
+          }
         },
         onTransactionError(txError) {
           rootActions.setTxState({

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -93,12 +93,14 @@ export const Step3: FC = () => {
             txHash: tx.hash,
           });
 
-          addTransaction({
-            status: "submitted",
-            hash: tx.hash,
-            chainId: sourceChain.chain_id,
-            txType: "INTERCHAIN_DEPLOYMENT",
-          });
+          if (rootState.selectedChains.length > 0) {
+            addTransaction({
+              status: "submitted",
+              hash: tx.hash,
+              chainId: sourceChain.chain_id,
+              txType: "INTERCHAIN_DEPLOYMENT",
+            });
+          }
         },
         onTransactionError(txError) {
           rootActions.setTxState({

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -97,6 +97,7 @@ export const Step3: FC = () => {
             status: "submitted",
             hash: tx.hash,
             chainId: sourceChain.chain_id,
+            txType: "INTERCHAIN_DEPLOYMENT",
           });
         },
         onTransactionError(txError) {

--- a/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
+++ b/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
@@ -115,6 +115,7 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
           status: "submitted",
           hash: tx.hash,
           chainId: props.originChainId ?? -1,
+          txType: "INTERCHAIN_DEPLOYMENT",
         });
       },
       onTransactionError(error) {

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
@@ -136,6 +136,7 @@ export const SendInterchainToken: FC<Props> = (props) => {
       status: "submitted",
       hash: txHash,
       chainId: props.sourceChain.chain_id,
+      txType: "INTERCHAIN_TRANSFER",
     });
   }, [actions, props.sourceChain, state.txState, txHash]);
 

--- a/apps/maestro/src/lib/hooks/useTransactionState.ts
+++ b/apps/maestro/src/lib/hooks/useTransactionState.ts
@@ -7,10 +7,12 @@ export type UnsubmittedTransactionState =
   | { status: "awaiting_spend_approval"; amount: bigint }
   | { status: "awaiting_approval" };
 
+export type TxType = "INTERCHAIN_DEPLOYMENT" | "INTERCHAIN_TRANSFER";
 export type SubmittedTransactionState<TError = Error> =
   | {
       status: "submitted";
       hash: `0x${string}`;
+      txType?: TxType;
       chainId: number;
       isGMP?: boolean;
     }
@@ -18,6 +20,7 @@ export type SubmittedTransactionState<TError = Error> =
       status: "confirmed";
       receipt: TransactionReceipt;
       hash?: `0x${string}`;
+      txType?: TxType;
       chainId?: number;
       isGMP?: boolean;
     }
@@ -25,6 +28,7 @@ export type SubmittedTransactionState<TError = Error> =
       status: "reverted";
       error: TError;
       hash?: `0x${string}`;
+      txType?: TxType;
       chainId?: number;
       isGMP?: boolean;
     };
@@ -55,6 +59,9 @@ export function useTransactionState<TError = Error>(
                 // retain the chainId from the previous state if nil
                 chainId:
                   "chainId" in newState ? newState.chainId : prevState.chainId,
+                // retain the txType from the previous state if nil
+                txType:
+                  "txType" in newState ? newState.txType : prevState.txType,
               } as TransactionState<TError>;
             default:
               return newState;

--- a/apps/maestro/src/services/gmp/hooks.ts
+++ b/apps/maestro/src/services/gmp/hooks.ts
@@ -66,7 +66,12 @@ export function useInterchainTokensQuery(input: {
   };
 }
 
-export function useGetTransactionType(input: { txHash?: `0x${string}` }) {
+export function useGetTransactionType(
+  input: { txHash?: `0x${string}` },
+  options: {
+    enabled?: boolean;
+  }
+) {
   const { data, ...query } = useQuery(
     ["gmp-get-transaction-type", input.txHash],
     async () => {
@@ -90,7 +95,9 @@ export function useGetTransactionType(input: { txHash?: `0x${string}` }) {
       return null;
     },
     {
-      enabled: Boolean(input.txHash?.match(/^(0x)?[0-9a-f]{64}/i)),
+      enabled: Boolean(
+        input.txHash?.match(/^(0x)?[0-9a-f]{64}/i) && options.enabled
+      ),
     }
   );
 

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
@@ -350,6 +350,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
                       status: "submitted",
                       hash: txState.hash,
                       chainId: originToken.chainId,
+                      txType: "INTERCHAIN_DEPLOYMENT",
                     });
                     break;
                   case "confirmed":


### PR DESCRIPTION
* preemptively track gmp tx types (prevent toasts hanging on `Loading tx type`)
* fix mutation enabled criteria for interchain deployments (allows deploying interchain tokens with no remote chains)
* only track interchain deployments with remote chains selected (avoid empty tx toasts)