### PR TITLE
feat: add deposit service

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,6 +16,7 @@
     "./axelar-query",
     "./gmp",
     "./deposit-address",
+    "./deposit-service",
     "./axelar-config",
     "./index.js",
     "./index.d.ts"

--- a/packages/api/src/axelar-config/types.ts
+++ b/packages/api/src/axelar-config/types.ts
@@ -2,9 +2,11 @@ export interface BaseAssetConfig {
   id: string;
   prettySymbol: string;
   symbol: string;
-  sourceChainId_internal: string;
-  sourceChainId_external: string | number;
-  registrationType: "network_asset" | "interchain_token";
+  originChainId: {
+    internal: string;
+    external: string;
+  };
+  registration: "network_asset" | "interchain_token";
   name: string;
   decimals: number;
   svg: string;
@@ -20,6 +22,7 @@ export interface ComosAssetConfig extends BaseAssetConfig {
 export interface EVMAssetConfig extends BaseAssetConfig {
   module: "evm";
   tokenAddress: string;
+  isERC20WrappedNativeGasToken?: boolean;
 }
 
 export type Asset = ComosAssetConfig | EVMAssetConfig;

--- a/packages/api/src/deposit-address/isomorphic.ts
+++ b/packages/api/src/deposit-address/isomorphic.ts
@@ -10,7 +10,7 @@ export class DepositAddressClient extends RestService {
   static init(options: RestServiceOptions) {
     return new DepositAddressClient(options, {
       name: "DepositAddressClient",
-      version: "0.0.1",
+      version: "0.1.0",
     });
   }
 
@@ -30,6 +30,4 @@ export class DepositAddressClient extends RestService {
       })
       .json<DepositAddressResponse>();
   }
-
-  // async requestDepositAddressForNativeWrap()
 }

--- a/packages/api/src/deposit-address/isomorphic.ts
+++ b/packages/api/src/deposit-address/isomorphic.ts
@@ -30,4 +30,6 @@ export class DepositAddressClient extends RestService {
       })
       .json<DepositAddressResponse>();
   }
+
+  // async requestDepositAddressForNativeWrap()
 }

--- a/packages/api/src/deposit-service/client.spec.ts
+++ b/packages/api/src/deposit-service/client.spec.ts
@@ -5,7 +5,7 @@ import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
 import { createDepositServiceApiClient } from "./client";
 
 describe("deposit service", () => {
-  test("get wrap deposit address", async () => {
+  test("wrap deposit address should return the address when passing params correctly", async () => {
     const client = createDepositServiceApiClient(ENVIRONMENTS.testnet);
     const salt = keccak256(
       encodeAbiParameters(parseAbiParameters("uint"), [
@@ -21,7 +21,7 @@ describe("deposit service", () => {
       salt,
     });
 
-    expect(response.address).toBeDefined();
+    expect(response).toBeDefined();
   });
 
   test("get unwrap deposit address", async () => {
@@ -34,6 +34,6 @@ describe("deposit service", () => {
       toChain: "Fantom",
     });
 
-    expect(response.address).toBeDefined();
+    expect(response).toBeDefined();
   });
 });

--- a/packages/api/src/deposit-service/client.spec.ts
+++ b/packages/api/src/deposit-service/client.spec.ts
@@ -23,4 +23,17 @@ describe("deposit service", () => {
 
     expect(response.address).toBeDefined();
   });
+
+  test("get unwrap deposit address", async () => {
+    const client = createDepositServiceApiClient(ENVIRONMENTS.testnet);
+
+    const response = await client.getDepositAddressForNativeUnwrap({
+      refundAddress: "0xdeadbeef29292929192939494959594933929292",
+      destinationAddress: "0xdeadbeef29292929192939494959594933929292",
+      fromChain: "Ethereum",
+      toChain: "Fantom",
+    });
+
+    expect(response.address).toBeDefined();
+  });
 });

--- a/packages/api/src/deposit-service/client.spec.ts
+++ b/packages/api/src/deposit-service/client.spec.ts
@@ -16,7 +16,7 @@ describe("deposit service", () => {
     const response = await client.getDepositAddressForNativeWrap({
       refundAddress: "0xdeadbeef29292929192939494959594933929292",
       destinationAddress: "0xdeadbeef29292929192939494959594933929292",
-      fromChain: "Ethereum",
+      fromChain: "Avalanche",
       toChain: "Fantom",
       salt,
     });
@@ -30,7 +30,7 @@ describe("deposit service", () => {
     const response = await client.getDepositAddressForNativeUnwrap({
       refundAddress: "0xdeadbeef29292929192939494959594933929292",
       destinationAddress: "0xdeadbeef29292929192939494959594933929292",
-      fromChain: "Ethereum",
+      fromChain: "Avalanche",
       toChain: "Fantom",
     });
 

--- a/packages/api/src/deposit-service/client.spec.ts
+++ b/packages/api/src/deposit-service/client.spec.ts
@@ -1,0 +1,26 @@
+import { ENVIRONMENTS } from "@axelarjs/core";
+
+import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
+
+import { createDepositServiceApiClient } from "./client";
+
+describe("deposit service", () => {
+  test("get wrap deposit address", async () => {
+    const client = createDepositServiceApiClient(ENVIRONMENTS.testnet);
+    const salt = keccak256(
+      encodeAbiParameters(parseAbiParameters("uint"), [
+        BigInt(new Date().getTime()),
+      ])
+    );
+
+    const response = await client.getDepositAddressForNativeWrap({
+      refundAddress: "0xdeadbeef29292929192939494959594933929292",
+      destinationAddress: "0xdeadbeef29292929192939494959594933929292",
+      fromChain: "Ethereum",
+      toChain: "Fantom",
+      salt,
+    });
+
+    expect(response.address).toBeDefined();
+  });
+});

--- a/packages/api/src/deposit-service/client.ts
+++ b/packages/api/src/deposit-service/client.ts
@@ -1,0 +1,16 @@
+import { DEPOSIT_SERVICE_API_URLS, type Environment } from "@axelarjs/core";
+import { HttpClient, HttpClientOptions } from "@axelarjs/utils/http-client";
+
+import { DepositServiceClient } from "./isomorphic";
+
+export const createDepositServiceApiClient = (
+  env: Environment,
+  options?: HttpClientOptions
+) =>
+  DepositServiceClient.init({
+    instance: HttpClient.extend({
+      ...(options ?? {
+        prefixUrl: DEPOSIT_SERVICE_API_URLS[env],
+      }),
+    }),
+  });

--- a/packages/api/src/deposit-service/index.ts
+++ b/packages/api/src/deposit-service/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./isomorphic";
+export * from "./client";

--- a/packages/api/src/deposit-service/isomorphic.ts
+++ b/packages/api/src/deposit-service/isomorphic.ts
@@ -1,0 +1,34 @@
+import { zeroAddress } from "viem";
+
+import { RestService, type RestServiceOptions } from "../lib/rest-service";
+import type {
+  DepositAddressNativeWrapParams,
+  DepositAddressNativeWrapResponse,
+} from "./types";
+
+export class DepositServiceClient extends RestService {
+  static init(options: RestServiceOptions) {
+    return new DepositServiceClient(options, {
+      name: "DepositServiceClient",
+      version: "0.0.1",
+    });
+  }
+
+  async getDepositAddressForNativeWrap(params: DepositAddressNativeWrapParams) {
+    const endpoint = `/deposit/wrap`;
+    const response = await this.client
+      .post(endpoint, {
+        json: {
+          salt: params.salt,
+          source_chain: params.fromChain,
+          destination_chain: params.toChain,
+          destination_address: params.destinationAddress,
+          refund_address: params.refundAddress,
+          token_symbol: zeroAddress,
+        },
+      })
+      .json<DepositAddressNativeWrapResponse>();
+
+    return response;
+  }
+}

--- a/packages/api/src/deposit-service/isomorphic.ts
+++ b/packages/api/src/deposit-service/isomorphic.ts
@@ -2,6 +2,8 @@ import { zeroAddress } from "viem";
 
 import { RestService, type RestServiceOptions } from "../lib/rest-service";
 import type {
+  DepositAddressNativeUnwrapParams,
+  DepositAddressNativeUnwrapResponse,
   DepositAddressNativeWrapParams,
   DepositAddressNativeWrapResponse,
 } from "./types";
@@ -28,6 +30,25 @@ export class DepositServiceClient extends RestService {
         },
       })
       .json<DepositAddressNativeWrapResponse>();
+
+    return response;
+  }
+
+  async getDepositAddressForNativeUnwrap(
+    params: DepositAddressNativeUnwrapParams
+  ) {
+    const endpoint = `/deposit/unwrap`;
+    const response = await this.client
+      .post(endpoint, {
+        json: {
+          source_chain: params.fromChain,
+          destination_chain: params.toChain,
+          destination_address: params.destinationAddress,
+          refund_address: params.refundAddress,
+          token_symbol: zeroAddress,
+        },
+      })
+      .json<DepositAddressNativeUnwrapResponse>();
 
     return response;
   }

--- a/packages/api/src/deposit-service/types.ts
+++ b/packages/api/src/deposit-service/types.ts
@@ -1,0 +1,11 @@
+export type DepositAddressNativeWrapParams = {
+  fromChain: string;
+  toChain: string;
+  destinationAddress: string;
+  refundAddress: string;
+  salt: string; // hex string
+};
+
+export type DepositAddressNativeWrapResponse = {
+  address: `0x${string}`;
+};

--- a/packages/api/src/deposit-service/types.ts
+++ b/packages/api/src/deposit-service/types.ts
@@ -6,12 +6,10 @@ export type DepositAddressNativeWrapParams = {
   salt: string; // hex string
 };
 
-export type DepositAddressNativeUnwrapParams = {
-  fromChain: string;
-  toChain: string;
-  destinationAddress: string;
-  refundAddress: string;
-};
+export type DepositAddressNativeUnwrapParams = Omit<
+  DepositAddressNativeWrapParams,
+  "salt"
+>;
 
 export type DepositAddressNativeWrapResponse = {
   address: `0x${string}`;

--- a/packages/api/src/deposit-service/types.ts
+++ b/packages/api/src/deposit-service/types.ts
@@ -6,6 +6,16 @@ export type DepositAddressNativeWrapParams = {
   salt: string; // hex string
 };
 
+export type DepositAddressNativeUnwrapParams = {
+  fromChain: string;
+  toChain: string;
+  destinationAddress: string;
+  refundAddress: string;
+};
+
 export type DepositAddressNativeWrapResponse = {
   address: `0x${string}`;
 };
+
+export type DepositAddressNativeUnwrapResponse =
+  DepositAddressNativeWrapResponse;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,3 +8,5 @@ export * from "./axelar-query";
 export * from "./axelar-config";
 // deposit-address
 export * from "./deposit-address";
+// deposit-service
+export * from "./deposit-service";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,3 +51,12 @@ export const DEPOSIT_SERVICE_API_URLS = {
   testnet: "https://deposit-service.testnet.axelar.dev",
   mainnet: "https://deposit-service.mainnet.axelar.dev",
 } as const;
+
+export type DepositServiceAPIUrl = keyof typeof DEPOSIT_SERVICE_API_URLS;
+
+export const AXELAR_RPC_URLS = {
+  testnet: "https://axelartest-rpc.quickapi.com",
+  mainnet: "https://axelar-rpc.quickapi.com",
+} as const;
+
+export type AxelarRPCUrl = keyof typeof AXELAR_RPC_URLS;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,6 @@ export const DEPOSIT_ADDRESS_API_URLS = {
 export type DepositAddressAPIUrl = keyof typeof DEPOSIT_ADDRESS_API_URLS;
 
 export const DEPOSIT_SERVICE_API_URLS = {
-  testnet: "https://deposit-service-devnet-release.devnet.axelar.dev",
+  testnet: "https://deposit-service.testnet.axelar.dev",
   mainnet: "https://deposit-service.mainnet.axelar.dev",
 } as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,3 +46,8 @@ export const DEPOSIT_ADDRESS_API_URLS = {
 } as const;
 
 export type DepositAddressAPIUrl = keyof typeof DEPOSIT_ADDRESS_API_URLS;
+
+export const DEPOSIT_SERVICE_API_URLS = {
+  testnet: "https://deposit-service-devnet-release.devnet.axelar.dev",
+  mainnet: "https://deposit-service.mainnet.axelar.dev",
+} as const;

--- a/packages/cosmos/package.json
+++ b/packages/cosmos/package.json
@@ -68,6 +68,7 @@
     "long": "^5.2.3"
   },
   "devDependencies": {
+    "@axelarjs/core": "workspace:*",
     "@tsconfig/strictest": "^2.0.2",
     "cosmjs-types": "^0.8.0",
     "rambda": "^8.6.0",

--- a/packages/cosmos/src/stargate/spec/constants.ts
+++ b/packages/cosmos/src/stargate/spec/constants.ts
@@ -1,1 +1,0 @@
-export const AXELAR_RPC_URL = "https://axelartest-rpc.quickapi.com";

--- a/packages/cosmos/src/stargate/spec/queryClient.spec.ts
+++ b/packages/cosmos/src/stargate/spec/queryClient.spec.ts
@@ -1,11 +1,11 @@
+import { AXELAR_RPC_URLS } from "@axelarjs/core";
 import { TokenType } from "@axelarjs/proto/axelar/evm/v1beta1/query";
 
 import { createAxelarQueryClient } from "../stargateClient";
-import { AXELAR_RPC_URL } from "./constants";
 
 describe("query client", () => {
   test("query erc20Tokens", async () => {
-    const client = await createAxelarQueryClient(AXELAR_RPC_URL);
+    const client = await createAxelarQueryClient(AXELAR_RPC_URLS.testnet);
 
     const erc20Tokens = await client.evm.eRC20Tokens({
       chain: "fantom",

--- a/packages/cosmos/src/stargate/spec/stargateClient.spec.ts
+++ b/packages/cosmos/src/stargate/spec/stargateClient.spec.ts
@@ -1,3 +1,5 @@
+import { AXELAR_RPC_URLS } from "@axelarjs/core";
+
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { toAccAddress } from "@cosmjs/stargate/build/queryclient/utils";
 
@@ -6,7 +8,6 @@ import {
   createAxelarSigningClient,
   getAxelarSigningClientOptions,
 } from "../stargateClient";
-import { AXELAR_RPC_URL } from "./constants";
 import { MOCK_BROADCAST_RESPONSE } from "./mock";
 
 describe("stargate client", () => {
@@ -28,7 +29,7 @@ describe("stargate client", () => {
     );
 
     const client = await createAxelarSigningClient(
-      AXELAR_RPC_URL,
+      AXELAR_RPC_URLS.testnet,
       offlineSigner
     );
 
@@ -66,7 +67,7 @@ describe("stargate client", () => {
     );
 
     const client = await createAxelarSigningClient(
-      AXELAR_RPC_URL,
+      AXELAR_RPC_URLS.testnet,
       offlineSigner
     );
 

--- a/packages/deposit-address/package.json
+++ b/packages/deposit-address/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@axelarjs/api": "workspace:*",
     "@axelarjs/core": "workspace:*",
+    "@axelarjs/cosmos": "workspace:*",
     "@axelarjs/utils": "workspace:*",
     "bech32": "^2.0.0",
     "viem": "1.21.4"

--- a/packages/deposit-address/package.json
+++ b/packages/deposit-address/package.json
@@ -54,6 +54,7 @@
     "@axelarjs/core": "workspace:*",
     "@axelarjs/cosmos": "workspace:*",
     "@axelarjs/utils": "workspace:*",
+    "@axelarjs/proto": "workspace:*",
     "bech32": "^2.0.0",
     "viem": "1.21.4"
   }

--- a/packages/deposit-address/src/get-deposit-address/client.ts
+++ b/packages/deposit-address/src/get-deposit-address/client.ts
@@ -1,10 +1,19 @@
+import { createDepositServiceApiClient } from "@axelarjs/api";
 import { createAxelarConfigClient } from "@axelarjs/api/axelar-config";
 import { createAxelarscanClient } from "@axelarjs/api/axelarscan";
 import { createDepositAddressApiClient } from "@axelarjs/api/deposit-address";
 import { createGMPClient } from "@axelarjs/api/gmp";
 
-import { getDepositAddress as baseGetDepositAddress } from "./isomorphic";
-import type { SendOptions } from "./types";
+import {
+  getDepositAddress as baseGetDepositAddress,
+  getNativeWrapDepositAddress as baseGetNativeDepositAddress,
+  getNativeUnwrapDepositAddress as baseGetNativeUnwrapDepositAddress,
+} from "./isomorphic";
+import type {
+  DepositNativeUnwrapOptions,
+  DepositNativeWrapOptions,
+  SendOptions,
+} from "./types";
 
 export function getDepositAddress(params: SendOptions) {
   const { environment } = params;
@@ -14,6 +23,28 @@ export function getDepositAddress(params: SendOptions) {
     gmpClient: createGMPClient(environment),
     depositAddressClient: createDepositAddressApiClient(environment),
     axelarscanClient: createAxelarscanClient(environment),
+  });
+}
+
+export function getNativeWrapDepositAddress(params: DepositNativeWrapOptions) {
+  const { environment } = params;
+
+  return baseGetNativeDepositAddress(params, {
+    configClient: createAxelarConfigClient(environment),
+    gmpClient: createGMPClient(environment),
+    depositServiceClient: createDepositServiceApiClient(environment),
+  });
+}
+
+export function getNativeUnwrapDepositAddress(
+  params: DepositNativeUnwrapOptions
+) {
+  const { environment } = params;
+
+  return baseGetNativeUnwrapDepositAddress(params, {
+    configClient: createAxelarConfigClient(environment),
+    gmpClient: createGMPClient(environment),
+    depositServiceClient: createDepositServiceApiClient(environment),
   });
 }
 

--- a/packages/deposit-address/src/get-deposit-address/client.ts
+++ b/packages/deposit-address/src/get-deposit-address/client.ts
@@ -5,7 +5,7 @@ import { createDepositAddressApiClient } from "@axelarjs/api/deposit-address";
 import { createGMPClient } from "@axelarjs/api/gmp";
 
 import {
-  getDepositAddress as baseGetDepositAddress,
+  getLinkedDepositAddress as baseGetLinkedDepositAddress,
   getNativeWrapDepositAddress as baseGetNativeDepositAddress,
   getNativeUnwrapDepositAddress as baseGetNativeUnwrapDepositAddress,
 } from "./isomorphic";
@@ -15,10 +15,12 @@ import type {
   SendOptions,
 } from "./types";
 
-export function getDepositAddress(params: SendOptions) {
+export function getDepositAddress() {}
+
+export function getLinkedDepositAddress(params: SendOptions) {
   const { environment } = params;
 
-  return baseGetDepositAddress(params, {
+  return baseGetLinkedDepositAddress(params, {
     configClient: createAxelarConfigClient(environment),
     gmpClient: createGMPClient(environment),
     depositAddressClient: createDepositAddressApiClient(environment),
@@ -48,4 +50,4 @@ export function getNativeUnwrapDepositAddress(
   });
 }
 
-export default getDepositAddress;
+export default getLinkedDepositAddress;

--- a/packages/deposit-address/src/get-deposit-address/client.ts
+++ b/packages/deposit-address/src/get-deposit-address/client.ts
@@ -5,17 +5,29 @@ import { createDepositAddressApiClient } from "@axelarjs/api/deposit-address";
 import { createGMPClient } from "@axelarjs/api/gmp";
 
 import {
+  getDepositAddress as baseGetDepositAddress,
   getLinkedDepositAddress as baseGetLinkedDepositAddress,
   getNativeWrapDepositAddress as baseGetNativeDepositAddress,
   getNativeUnwrapDepositAddress as baseGetNativeUnwrapDepositAddress,
 } from "./isomorphic";
 import type {
+  DepositAddressOptions,
   DepositNativeUnwrapOptions,
   DepositNativeWrapOptions,
   SendOptions,
 } from "./types";
 
-export function getDepositAddress() {}
+export function getDepositAddress(params: DepositAddressOptions) {
+  const { environment } = params;
+
+  return baseGetDepositAddress(params, {
+    configClient: createAxelarConfigClient(environment),
+    gmpClient: createGMPClient(environment),
+    depositAddressClient: createDepositAddressApiClient(environment),
+    axelarscanClient: createAxelarscanClient(environment),
+    depositServiceClient: createDepositServiceApiClient(environment),
+  });
+}
 
 export function getLinkedDepositAddress(params: SendOptions) {
   const { environment } = params;

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.spec.ts
@@ -1,0 +1,25 @@
+import { createAxelarConfigClient } from "@axelarjs/api";
+import { ENVIRONMENTS } from "@axelarjs/core";
+
+import { unwrappable } from "./depositService";
+
+describe("depositService - helper", () => {
+  describe("unwrappable", () => {
+    test("should return true if destination chain is EVM and asset is wrapped native gas token", async () => {
+      const env = ENVIRONMENTS.testnet;
+      const configClients = createAxelarConfigClient(env);
+      const chainConfigs = await configClients.getChainConfigs(env);
+
+      Object.entries(chainConfigs.chains).forEach(([chainId, chainConfig]) => {
+        const { assets } = chainConfig;
+        assets.map((asset) => {
+          if (asset.module === "evm" && asset.isERC20WrappedNativeGasToken) {
+            expect(unwrappable(chainId, asset.id, chainConfigs)).toBeTruthy();
+          } else {
+            expect(unwrappable(chainId, asset.id, chainConfigs)).toBeFalsy();
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.spec.ts
@@ -24,7 +24,7 @@ describe("depositService - helper", () => {
   });
 
   describe("getActiveChains", () => {
-    test.only("should return a list of active chains", async () => {
+    test("should return a list of active chains", async () => {
       const env = ENVIRONMENTS.testnet;
       const activeChains = await getActiveChains(env);
       expect(activeChains.length).toBeGreaterThan(0);

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.spec.ts
@@ -1,7 +1,7 @@
 import { createAxelarConfigClient } from "@axelarjs/api";
 import { ENVIRONMENTS } from "@axelarjs/core";
 
-import { unwrappable } from "./depositService";
+import { getActiveChains, unwrappable } from "./depositService";
 
 describe("depositService - helper", () => {
   describe("unwrappable", () => {
@@ -20,6 +20,14 @@ describe("depositService - helper", () => {
           }
         });
       });
+    });
+  });
+
+  describe("getActiveChains", () => {
+    test.only("should return a list of active chains", async () => {
+      const env = ENVIRONMENTS.testnet;
+      const activeChains = await getActiveChains(env);
+      expect(activeChains.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -1,29 +1,22 @@
 import { ChainConfigsResponse } from "@axelarjs/api";
 
 export function unwrappable(
-  sourceChain: string,
   destinationChain: string,
   asset: string,
   chainConfigs: ChainConfigsResponse
 ) {
-  const sourceChainConfig = chainConfigs.chains[sourceChain.toLowerCase()];
   const destinationChainConfig =
     chainConfigs.chains[destinationChain.toLowerCase()];
 
-  if (!sourceChainConfig || !destinationChainConfig) return false;
+  if (!destinationChainConfig) return false;
 
-  // Do not allow unwrapping to non-EVM chains
-  if (destinationChainConfig.module !== "evm") return false;
+  const destAsset = destinationChainConfig.assets.find(
+    ({ id }) => id === asset
+  );
 
-  const evmDestinationChainConfig = destinationChainConfig;
+  if (destAsset?.module === "evm" && destAsset.isERC20WrappedNativeGasToken) {
+    return true;
+  }
 
-  const srcAsset = sourceChainConfig.assets.find(({ id }) => id === asset);
-
-  if (!srcAsset) false;
-
-  const isOriginChainMatchedDestinationChain =
-    srcAsset?.originChainId.internal === evmDestinationChainConfig.id;
-  console.log(isOriginChainMatchedDestinationChain);
   return false;
-  // const isNativeAsset = evmDestinationChainConfig.
 }

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -1,10 +1,9 @@
 import { ChainConfigsResponse } from "@axelarjs/api";
 import { AXELAR_RPC_URLS, Environment } from "@axelarjs/core";
 import { createAxelarQueryClient } from "@axelarjs/cosmos";
+import { ChainStatus } from "@axelarjs/proto/axelar/nexus/v1beta1/query";
 
 import { encodeAbiParameters, keccak256 } from "viem";
-
-import { ChainStatus } from "../../../../proto/build/module/axelar/nexus/v1beta1/query";
 
 export function unwrappable(
   destinationChain: string,

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -1,5 +1,7 @@
 import { ChainConfigsResponse } from "@axelarjs/api";
 
+import { encodeAbiParameters, keccak256 } from "viem";
+
 export function unwrappable(
   destinationChain: string,
   asset: string,
@@ -19,4 +21,22 @@ export function unwrappable(
   }
 
   return false;
+}
+
+export function generateRandomSalt(destinationAddress: string) {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        {
+          type: "uint256",
+          name: "timestamp",
+        },
+        {
+          type: "string",
+          name: "destinationAddress",
+        },
+      ],
+      [BigInt(new Date().getTime()), destinationAddress]
+    )
+  );
 }

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -19,17 +19,10 @@ export function unwrappable(
     ({ id }) => id === asset
   );
 
-  if (destAsset?.module === "evm" && destAsset.isERC20WrappedNativeGasToken) {
-    return true;
-  }
-
-  return false;
+  return destAsset?.module === "evm" && destAsset.isERC20WrappedNativeGasToken;
 }
 
-export async function getActiveChains(
-  environment: Environment
-  // chainConfigs: ChainConfig[]
-) {
+export async function getActiveChains(environment: Environment) {
   const axelarQueryClient = await createAxelarQueryClient(
     AXELAR_RPC_URLS[environment]
   );

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -1,6 +1,10 @@
 import { ChainConfigsResponse } from "@axelarjs/api";
+import { AXELAR_RPC_URLS, Environment } from "@axelarjs/core";
+import { createAxelarQueryClient } from "@axelarjs/cosmos";
 
 import { encodeAbiParameters, keccak256 } from "viem";
+
+import { ChainStatus } from "../../../../proto/build/module/axelar/nexus/v1beta1/query";
 
 export function unwrappable(
   destinationChain: string,
@@ -21,6 +25,19 @@ export function unwrappable(
   }
 
   return false;
+}
+
+export async function getActiveChains(
+  environment: Environment
+  // chainConfigs: ChainConfig[]
+) {
+  const axelarQueryClient = await createAxelarQueryClient(
+    AXELAR_RPC_URLS[environment]
+  );
+
+  return axelarQueryClient.nexus
+    .chains({ status: ChainStatus.CHAIN_STATUS_ACTIVATED })
+    .then(({ chains }) => chains.map((chain) => chain.toLowerCase()));
 }
 
 export function generateRandomSalt(destinationAddress: string) {

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -3,8 +3,6 @@ import { AXELAR_RPC_URLS, Environment } from "@axelarjs/core";
 import { createAxelarQueryClient } from "@axelarjs/cosmos";
 import { ChainStatus } from "@axelarjs/proto/axelar/nexus/v1beta1/query";
 
-import { encodeAbiParameters, keccak256 } from "viem";
-
 export function unwrappable(
   destinationChain: string,
   asset: string,
@@ -30,22 +28,4 @@ export async function getActiveChains(environment: Environment) {
   return axelarQueryClient.nexus
     .chains({ status: ChainStatus.CHAIN_STATUS_ACTIVATED })
     .then(({ chains }) => chains.map((chain) => chain.toLowerCase()));
-}
-
-export function generateRandomSalt(destinationAddress: string) {
-  return keccak256(
-    encodeAbiParameters(
-      [
-        {
-          type: "uint256",
-          name: "timestamp",
-        },
-        {
-          type: "string",
-          name: "destinationAddress",
-        },
-      ],
-      [BigInt(new Date().getTime()), destinationAddress]
-    )
-  );
 }

--- a/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/depositService.ts
@@ -1,0 +1,29 @@
+import { ChainConfigsResponse } from "@axelarjs/api";
+
+export function unwrappable(
+  sourceChain: string,
+  destinationChain: string,
+  asset: string,
+  chainConfigs: ChainConfigsResponse
+) {
+  const sourceChainConfig = chainConfigs.chains[sourceChain.toLowerCase()];
+  const destinationChainConfig =
+    chainConfigs.chains[destinationChain.toLowerCase()];
+
+  if (!sourceChainConfig || !destinationChainConfig) return false;
+
+  // Do not allow unwrapping to non-EVM chains
+  if (destinationChainConfig.module !== "evm") return false;
+
+  const evmDestinationChainConfig = destinationChainConfig;
+
+  const srcAsset = sourceChainConfig.assets.find(({ id }) => id === asset);
+
+  if (!srcAsset) false;
+
+  const isOriginChainMatchedDestinationChain =
+    srcAsset?.originChainId.internal === evmDestinationChainConfig.id;
+  console.log(isOriginChainMatchedDestinationChain);
+  return false;
+  // const isNativeAsset = evmDestinationChainConfig.
+}

--- a/packages/deposit-address/src/get-deposit-address/helpers/getDepositAddressFromAxelarNetwork.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/getDepositAddressFromAxelarNetwork.ts
@@ -6,7 +6,10 @@ import type {
 } from "@axelarjs/api";
 import { caseInsensitiveEqual, poll } from "@axelarjs/utils";
 
-import type { GetDepositAddressDependencies, SendOptions } from "../types";
+import type {
+  GetLinkedDepositAddressDependencies,
+  SendOptions,
+} from "../types";
 import { createDummyAccount, signOtc } from "./account";
 
 export type ListenerParams = {
@@ -19,7 +22,7 @@ export type ListenerParams = {
 export async function getDepositAddressFromAxelarNetwork(
   params: SendOptions,
   chainConfigs: ChainConfigsResponse,
-  dependencies: GetDepositAddressDependencies
+  dependencies: GetLinkedDepositAddressDependencies
 ) {
   /**
    * invoke API to get deposit address

--- a/packages/deposit-address/src/get-deposit-address/helpers/index.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./getDepositAddressFromAxelarNetwork";
 export * from "./validation";
 export * from "./account";
+export * from "./depositService";

--- a/packages/deposit-address/src/get-deposit-address/helpers/validation.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/validation.ts
@@ -2,9 +2,29 @@ import type {
   ChainConfig,
   ChainConfigsResponse,
 } from "@axelarjs/api/axelar-config/types";
+import { Environment } from "@axelarjs/core";
 
 import { bech32 } from "bech32";
 import { isAddress } from "viem";
+
+import { getActiveChains } from "./depositService";
+
+export async function validateAddressAndChains(
+  sourceChain: string,
+  destinationChain: string,
+  destinationAddress: string,
+  chainConfigs: ChainConfigsResponse,
+  environment: Environment
+) {
+  validateAddress(
+    destinationAddress,
+    chainConfigs.chains[destinationChain.toLowerCase()] as ChainConfig
+  );
+  validateChainIds([sourceChain, destinationChain], chainConfigs);
+
+  const activeChains = await getActiveChains(environment);
+  validateActiveChains([sourceChain, destinationChain], activeChains);
+}
 
 export function validateAddress(
   destinationAddress: string,

--- a/packages/deposit-address/src/get-deposit-address/helpers/validation.ts
+++ b/packages/deposit-address/src/get-deposit-address/helpers/validation.ts
@@ -37,6 +37,16 @@ export function validateChainIds(
   });
 }
 
+export function validateActiveChains(
+  chainIds: string[],
+  activeChains: string[]
+) {
+  chainIds.forEach((chainId) => {
+    if (!activeChains.includes(chainId.toLowerCase()))
+      throw new Error(`chain ID ${chainId} is not active`);
+  });
+}
+
 export function validateAsset(
   chainIds: string[],
   assetId: string,

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -3,7 +3,7 @@ import { ENVIRONMENTS } from "@axelarjs/core";
 import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
 
 import {
-  getDepositAddress,
+  getLinkedDepositAddress,
   getNativeUnwrapDepositAddress,
   getNativeWrapDepositAddress,
 } from "./client";
@@ -22,7 +22,7 @@ describe("getDepositAddress - node", () => {
       destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
       environment: ENVIRONMENTS.testnet,
     };
-    const res = await getDepositAddress(params);
+    const res = await getLinkedDepositAddress(params);
 
     expect(res?.depositAddress).toBeTruthy();
     expect(res?.sourceChain?.toLowerCase()).toEqual(
@@ -39,7 +39,7 @@ describe("getDepositAddress - node", () => {
       destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
       environment: ENVIRONMENTS.testnet,
     };
-    const res = await getDepositAddress(params);
+    const res = await getLinkedDepositAddress(params);
 
     expect(res?.depositAddress).toBeTruthy();
     expect(res?.sourceChain?.toLowerCase()).toEqual("axelarnet");

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -15,11 +15,12 @@ import type {
 
 describe("Deposit Address", () => {
   describe("getDepositAddress", () => {
-    test("should get the deposit address if the asset is undefined", async () => {
+    test("should get the deposit address if the asset is 'native'", async () => {
       const params: DepositAddressOptions = {
         sourceChain: "Avalanche",
         destinationChain: "Fantom",
         destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        asset: "native",
         environment: ENVIRONMENTS.testnet,
       };
 

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -14,7 +14,7 @@ import type {
 } from "./types";
 
 describe("getDepositAddress - node", () => {
-  test("get deposit address from an EVM source chain", async () => {
+  test("should get deposit address from an EVM source chain", async () => {
     const params: SendOptions = {
       sourceChain: "Fantom",
       destinationChain: "ethereum-2",
@@ -30,7 +30,8 @@ describe("getDepositAddress - node", () => {
     );
     expect(res?.depositAddress?.startsWith("0x")).toBeTruthy();
   });
-  test("get deposit address from an cosmos-based source chain", async () => {
+
+  test("should get deposit address from an cosmos-based source chain", async () => {
     const params: SendOptions = {
       sourceChain: "osmosis-7",
       destinationChain: "ethereum-2",
@@ -45,7 +46,7 @@ describe("getDepositAddress - node", () => {
     expect(res?.depositAddress?.startsWith("axelar")).toBeTruthy();
   });
 
-  test.only("should receive an address for wrap deposit address", async () => {
+  test("should receive an address for wrap deposit address", async () => {
     const salt = keccak256(
       encodeAbiParameters(parseAbiParameters("uint"), [
         BigInt(new Date().getTime()),
@@ -64,7 +65,7 @@ describe("getDepositAddress - node", () => {
     expect(depositAddress).toBeDefined();
   });
 
-  test.only("should receive an address for unwrap deposit address", async () => {
+  test("should receive an address for unwrap deposit address", async () => {
     const params: DepositNativeUnwrapOptions = {
       sourceChain: "Fantom",
       destinationChain: "Avalanche",
@@ -75,5 +76,64 @@ describe("getDepositAddress - node", () => {
 
     const depositAddress = await getNativeUnwrapDepositAddress(params);
     expect(depositAddress).toBeDefined();
+  });
+
+  test("should throw error when passing invalid source chain or dest chain to wrap deposit address", async () => {
+    const salt = keccak256(
+      encodeAbiParameters(parseAbiParameters("uint"), [
+        BigInt(new Date().getTime()),
+      ])
+    );
+    const invalidSourceParams: DepositNativeWrapOptions = {
+      sourceChain: "Avax",
+      destinationChain: "Fantom",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      salt,
+      environment: ENVIRONMENTS.testnet,
+    };
+
+    await expect(
+      getNativeWrapDepositAddress(invalidSourceParams)
+    ).rejects.toThrowError();
+
+    const invalidDestParams: DepositNativeWrapOptions = {
+      sourceChain: "Avalanche",
+      destinationChain: "Ftm",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      salt,
+      environment: ENVIRONMENTS.testnet,
+    };
+
+    await expect(
+      getNativeWrapDepositAddress(invalidDestParams)
+    ).rejects.toThrowError();
+  });
+
+  test("should throw error when passing invalid source chain or dest chain to unwrap deposit address", async () => {
+    const invalidSourceParams: DepositNativeUnwrapOptions = {
+      sourceChain: "Avax",
+      destinationChain: "Fantom",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      environment: ENVIRONMENTS.testnet,
+    };
+
+    await expect(
+      getNativeUnwrapDepositAddress(invalidSourceParams)
+    ).rejects.toThrowError();
+
+    const invalidDestParams: DepositNativeUnwrapOptions = {
+      sourceChain: "Avalanche",
+      destinationChain: "Ftm",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      environment: ENVIRONMENTS.testnet,
+    };
+
+    await expect(
+      getNativeUnwrapDepositAddress(invalidDestParams)
+    ).rejects.toThrowError();
   });
 });

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -1,7 +1,17 @@
 import { ENVIRONMENTS } from "@axelarjs/core";
 
-import getDepositAddress from "./client";
-import type { SendOptions } from "./types";
+import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
+
+import {
+  getDepositAddress,
+  getNativeUnwrapDepositAddress,
+  getNativeWrapDepositAddress,
+} from "./client";
+import type {
+  DepositNativeUnwrapOptions,
+  DepositNativeWrapOptions,
+  SendOptions,
+} from "./types";
 
 describe("getDepositAddress - node", () => {
   test("get deposit address from an EVM source chain", async () => {
@@ -35,7 +45,35 @@ describe("getDepositAddress - node", () => {
     expect(res?.depositAddress?.startsWith("axelar")).toBeTruthy();
   });
 
-  test("get native deposit address", async () => {
-    // console.log()
+  test.only("should receive an address for wrap deposit address", async () => {
+    const salt = keccak256(
+      encodeAbiParameters(parseAbiParameters("uint"), [
+        BigInt(new Date().getTime()),
+      ])
+    );
+    const params: DepositNativeWrapOptions = {
+      sourceChain: "Avalanche",
+      destinationChain: "Fantom",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      salt,
+      environment: ENVIRONMENTS.testnet,
+    };
+
+    const depositAddress = await getNativeWrapDepositAddress(params);
+    expect(depositAddress).toBeDefined();
+  });
+
+  test.only("should receive an address for unwrap deposit address", async () => {
+    const params: DepositNativeUnwrapOptions = {
+      sourceChain: "Fantom",
+      destinationChain: "Avalanche",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      environment: ENVIRONMENTS.testnet,
+    };
+
+    const depositAddress = await getNativeUnwrapDepositAddress(params);
+    expect(depositAddress).toBeDefined();
   });
 });

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -3,17 +3,31 @@ import { ENVIRONMENTS } from "@axelarjs/core";
 import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
 
 import {
+  getDepositAddress,
   getLinkedDepositAddress,
   getNativeUnwrapDepositAddress,
   getNativeWrapDepositAddress,
 } from "./client";
 import type {
+  DepositAddressOptions,
   DepositNativeUnwrapOptions,
   DepositNativeWrapOptions,
   SendOptions,
 } from "./types";
 
 describe("getDepositAddress - node", () => {
+  test.only("should get deposit address", async () => {
+    const params: DepositAddressOptions = {
+      sourceChain: "Avalanche",
+      destinationChain: "Fantom",
+      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+      environment: ENVIRONMENTS.mainnet,
+    };
+
+    const res = await getDepositAddress(params);
+    console.log(res);
+  });
+
   test("should get deposit address from an EVM source chain", async () => {
     const params: SendOptions = {
       sourceChain: "Fantom",

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -34,4 +34,8 @@ describe("getDepositAddress - node", () => {
     expect(res?.sourceChain?.toLowerCase()).toEqual("axelarnet");
     expect(res?.depositAddress?.startsWith("axelar")).toBeTruthy();
   });
+
+  test("get native deposit address", async () => {
+    // console.log()
+  });
 });

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -146,6 +146,18 @@ describe("Deposit Address", () => {
       expect(depositAddress).toBeDefined();
     });
 
+    test("should get inactive chain error", async () => {
+      const params: DepositNativeWrapOptions = {
+        sourceChain: "terra",
+        destinationChain: "Fantom",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+
+      await expect(getNativeWrapDepositAddress(params)).rejects.toThrowError();
+    });
+
     test("should throw error when passing invalid source chain or dest chain to wrap deposit address", async () => {
       const invalidSourceParams: DepositNativeWrapOptions = {
         sourceChain: "Avax",

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.spec.ts
@@ -1,7 +1,5 @@
 import { ENVIRONMENTS } from "@axelarjs/core";
 
-import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
-
 import {
   getDepositAddress,
   getLinkedDepositAddress,
@@ -15,139 +13,163 @@ import type {
   SendOptions,
 } from "./types";
 
-describe("getDepositAddress - node", () => {
-  test.only("should get deposit address", async () => {
-    const params: DepositAddressOptions = {
-      sourceChain: "Avalanche",
-      destinationChain: "Fantom",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      environment: ENVIRONMENTS.mainnet,
-    };
+describe("Deposit Address", () => {
+  describe("getDepositAddress", () => {
+    test("should get the deposit address if the asset is undefined", async () => {
+      const params: DepositAddressOptions = {
+        sourceChain: "Avalanche",
+        destinationChain: "Fantom",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
 
-    const res = await getDepositAddress(params);
-    console.log(res);
+      const depositAddress = await getDepositAddress(params);
+
+      expect(depositAddress).toBeDefined();
+    });
+
+    test("should get the deposit address if the asset is defined, but unwrappable at the destination chain", async () => {
+      const params: DepositAddressOptions = {
+        sourceChain: "Avalanche",
+        destinationChain: "Fantom",
+        asset: "wftm-wei",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+
+      const depositAddress = await getDepositAddress(params);
+
+      expect(depositAddress).toBeDefined();
+    });
+
+    test("should get the deposit address if the asset is defined and not unwrappable at the destination chain", async () => {
+      const params: DepositAddressOptions = {
+        sourceChain: "Avalanche",
+        destinationChain: "Fantom",
+        asset: "wavax-wei",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+
+      const depositAddress = await getDepositAddress(params);
+
+      expect(depositAddress).toBeDefined();
+    });
   });
 
-  test("should get deposit address from an EVM source chain", async () => {
-    const params: SendOptions = {
-      sourceChain: "Fantom",
-      destinationChain: "ethereum-2",
-      asset: "uaxl",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      environment: ENVIRONMENTS.testnet,
-    };
-    const res = await getLinkedDepositAddress(params);
+  describe("getLinkedDepositAddress", () => {
+    test("should get linked deposit address from an EVM source chain", async () => {
+      const params: SendOptions = {
+        sourceChain: "Fantom",
+        destinationChain: "ethereum-2",
+        asset: "uaxl",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+      const res = await getLinkedDepositAddress(params);
 
-    expect(res?.depositAddress).toBeTruthy();
-    expect(res?.sourceChain?.toLowerCase()).toEqual(
-      params.sourceChain.toLowerCase()
-    );
-    expect(res?.depositAddress?.startsWith("0x")).toBeTruthy();
+      expect(res?.depositAddress).toBeTruthy();
+      expect(res?.sourceChain?.toLowerCase()).toEqual(
+        params.sourceChain.toLowerCase()
+      );
+      expect(res?.depositAddress?.startsWith("0x")).toBeTruthy();
+    });
+
+    test("should get linked deposit address from an cosmos-based source chain", async () => {
+      const params: SendOptions = {
+        sourceChain: "osmosis-7",
+        destinationChain: "ethereum-2",
+        asset: "uaxl",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+      const res = await getLinkedDepositAddress(params);
+
+      expect(res?.depositAddress).toBeTruthy();
+      expect(res?.sourceChain?.toLowerCase()).toEqual("axelarnet");
+      expect(res?.depositAddress?.startsWith("axelar")).toBeTruthy();
+    });
   });
 
-  test("should get deposit address from an cosmos-based source chain", async () => {
-    const params: SendOptions = {
-      sourceChain: "osmosis-7",
-      destinationChain: "ethereum-2",
-      asset: "uaxl",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      environment: ENVIRONMENTS.testnet,
-    };
-    const res = await getLinkedDepositAddress(params);
+  describe("getNativeUnwrapDepositAddress", () => {
+    test("should receive an address for unwrap deposit address", async () => {
+      const params: DepositNativeUnwrapOptions = {
+        sourceChain: "Fantom",
+        destinationChain: "Avalanche",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
 
-    expect(res?.depositAddress).toBeTruthy();
-    expect(res?.sourceChain?.toLowerCase()).toEqual("axelarnet");
-    expect(res?.depositAddress?.startsWith("axelar")).toBeTruthy();
+      const depositAddress = await getNativeUnwrapDepositAddress(params);
+      expect(depositAddress).toBeDefined();
+    });
+
+    test("should throw error when passing invalid source chain or dest chain to unwrap deposit address", async () => {
+      const invalidSourceParams: DepositNativeUnwrapOptions = {
+        sourceChain: "Avax",
+        destinationChain: "Fantom",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+
+      await expect(
+        getNativeUnwrapDepositAddress(invalidSourceParams)
+      ).rejects.toThrowError();
+
+      const invalidDestParams: DepositNativeUnwrapOptions = {
+        sourceChain: "Avalanche",
+        destinationChain: "Ftm",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
+
+      await expect(
+        getNativeUnwrapDepositAddress(invalidDestParams)
+      ).rejects.toThrowError();
+    });
   });
 
-  test("should receive an address for wrap deposit address", async () => {
-    const salt = keccak256(
-      encodeAbiParameters(parseAbiParameters("uint"), [
-        BigInt(new Date().getTime()),
-      ])
-    );
-    const params: DepositNativeWrapOptions = {
-      sourceChain: "Avalanche",
-      destinationChain: "Fantom",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      salt,
-      environment: ENVIRONMENTS.testnet,
-    };
+  describe("getNativeWrapDepositAddress", () => {
+    test("should receive an address for wrap deposit address", async () => {
+      const params: DepositNativeWrapOptions = {
+        sourceChain: "Avalanche",
+        destinationChain: "Fantom",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
 
-    const depositAddress = await getNativeWrapDepositAddress(params);
-    expect(depositAddress).toBeDefined();
-  });
+      const depositAddress = await getNativeWrapDepositAddress(params);
+      expect(depositAddress).toBeDefined();
+    });
 
-  test("should receive an address for unwrap deposit address", async () => {
-    const params: DepositNativeUnwrapOptions = {
-      sourceChain: "Fantom",
-      destinationChain: "Avalanche",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      environment: ENVIRONMENTS.testnet,
-    };
+    test("should throw error when passing invalid source chain or dest chain to wrap deposit address", async () => {
+      const invalidSourceParams: DepositNativeWrapOptions = {
+        sourceChain: "Avax",
+        destinationChain: "Fantom",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
 
-    const depositAddress = await getNativeUnwrapDepositAddress(params);
-    expect(depositAddress).toBeDefined();
-  });
+      await expect(
+        getNativeWrapDepositAddress(invalidSourceParams)
+      ).rejects.toThrowError();
 
-  test("should throw error when passing invalid source chain or dest chain to wrap deposit address", async () => {
-    const salt = keccak256(
-      encodeAbiParameters(parseAbiParameters("uint"), [
-        BigInt(new Date().getTime()),
-      ])
-    );
-    const invalidSourceParams: DepositNativeWrapOptions = {
-      sourceChain: "Avax",
-      destinationChain: "Fantom",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      salt,
-      environment: ENVIRONMENTS.testnet,
-    };
+      const invalidDestParams: DepositNativeWrapOptions = {
+        sourceChain: "Avalanche",
+        destinationChain: "Ftm",
+        destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        environment: ENVIRONMENTS.testnet,
+      };
 
-    await expect(
-      getNativeWrapDepositAddress(invalidSourceParams)
-    ).rejects.toThrowError();
-
-    const invalidDestParams: DepositNativeWrapOptions = {
-      sourceChain: "Avalanche",
-      destinationChain: "Ftm",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      salt,
-      environment: ENVIRONMENTS.testnet,
-    };
-
-    await expect(
-      getNativeWrapDepositAddress(invalidDestParams)
-    ).rejects.toThrowError();
-  });
-
-  test("should throw error when passing invalid source chain or dest chain to unwrap deposit address", async () => {
-    const invalidSourceParams: DepositNativeUnwrapOptions = {
-      sourceChain: "Avax",
-      destinationChain: "Fantom",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      environment: ENVIRONMENTS.testnet,
-    };
-
-    await expect(
-      getNativeUnwrapDepositAddress(invalidSourceParams)
-    ).rejects.toThrowError();
-
-    const invalidDestParams: DepositNativeUnwrapOptions = {
-      sourceChain: "Avalanche",
-      destinationChain: "Ftm",
-      destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      refundAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
-      environment: ENVIRONMENTS.testnet,
-    };
-
-    await expect(
-      getNativeUnwrapDepositAddress(invalidDestParams)
-    ).rejects.toThrowError();
+      await expect(
+        getNativeWrapDepositAddress(invalidDestParams)
+      ).rejects.toThrowError();
+    });
   });
 });

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -72,7 +72,7 @@ export async function getDepositAddress(
         dependencies
       ).then((res) => res?.depositAddress);
 
-    if (shouldUnwrapToken) {
+    if (shouldUnwrapToken && !params.options?.skipUnwrap) {
       // the token is unwrappable, we need to get the native unwrap deposit address first.
       const unwrappedDepositAddress = await getNativeUnwrapDepositAddress(
         {

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -1,7 +1,6 @@
 import type { ChainConfig } from "@axelarjs/api";
 
 import {
-  generateRandomSalt,
   getActiveChains,
   getDepositAddressFromAxelarNetwork,
   unwrappable,
@@ -147,7 +146,7 @@ export async function getNativeWrapDepositAddress(
       destinationAddress: params.destinationAddress,
       fromChain: params.sourceChain,
       toChain: params.destinationChain,
-      salt: params.salt || generateRandomSalt(params.destinationAddress),
+      salt: params.salt || "0x", // we would like to re-used the same salt to utilize the same deposit address
     });
 
   return address;

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -1,13 +1,8 @@
-import type { ChainConfig } from "@axelarjs/api";
-
 import {
-  getActiveChains,
   getDepositAddressFromAxelarNetwork,
   unwrappable,
-  validateActiveChains,
-  validateAddress,
+  validateAddressAndChains,
   validateAsset,
-  validateChainIds,
 } from "./helpers";
 import type {
   DepositAddressOptions,
@@ -106,15 +101,18 @@ export async function getLinkedDepositAddress(
   /**
    * input validation
    */
-  validateChainIds([params.sourceChain, params.destinationChain], chainConfigs);
+
   validateAsset(
     [params.sourceChain, params.destinationChain],
     params.asset,
     chainConfigs
   );
-  validateAddress(
+  await validateAddressAndChains(
+    params.sourceChain,
+    params.destinationChain,
     params.destinationAddress,
-    chainConfigs.chains[params.destinationChain.toLowerCase()] as ChainConfig
+    chainConfigs,
+    params.environment
   );
 
   return getDepositAddressFromAxelarNetwork(params, chainConfigs, dependencies);
@@ -128,16 +126,12 @@ export async function getNativeWrapDepositAddress(
     params.environment
   );
 
-  validateChainIds([params.sourceChain, params.destinationChain], chainConfigs);
-  validateAddress(
+  await validateAddressAndChains(
+    params.sourceChain,
+    params.destinationChain,
     params.destinationAddress,
-    chainConfigs.chains[params.destinationChain.toLowerCase()] as ChainConfig
-  );
-
-  const activeChains = await getActiveChains(params.environment);
-  validateActiveChains(
-    [params.sourceChain, params.destinationChain],
-    activeChains
+    chainConfigs,
+    params.environment
   );
 
   const { address } =
@@ -160,16 +154,12 @@ export async function getNativeUnwrapDepositAddress(
     params.environment
   );
 
-  validateChainIds([params.sourceChain, params.destinationChain], chainConfigs);
-  validateAddress(
+  await validateAddressAndChains(
+    params.sourceChain,
+    params.destinationChain,
     params.destinationAddress,
-    chainConfigs.chains[params.destinationChain.toLowerCase()] as ChainConfig
-  );
-
-  const activeChains = await getActiveChains(params.environment);
-  validateActiveChains(
-    [params.sourceChain, params.destinationChain],
-    activeChains
+    chainConfigs,
+    params.environment
   );
 
   const { address } =

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -2,8 +2,10 @@ import type { ChainConfig } from "@axelarjs/api";
 
 import {
   generateRandomSalt,
+  getActiveChains,
   getDepositAddressFromAxelarNetwork,
   unwrappable,
+  validateActiveChains,
   validateAddress,
   validateAsset,
   validateChainIds,
@@ -133,6 +135,12 @@ export async function getNativeWrapDepositAddress(
     chainConfigs.chains[params.destinationChain.toLowerCase()] as ChainConfig
   );
 
+  const activeChains = await getActiveChains(params.environment);
+  validateActiveChains(
+    [params.sourceChain, params.destinationChain],
+    activeChains
+  );
+
   const { address } =
     await dependencies.depositServiceClient.getDepositAddressForNativeWrap({
       refundAddress: params.refundAddress,
@@ -157,6 +165,12 @@ export async function getNativeUnwrapDepositAddress(
   validateAddress(
     params.destinationAddress,
     chainConfigs.chains[params.destinationChain.toLowerCase()] as ChainConfig
+  );
+
+  const activeChains = await getActiveChains(params.environment);
+  validateActiveChains(
+    [params.sourceChain, params.destinationChain],
+    activeChains
   );
 
   const { address } =

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -9,14 +9,16 @@ import {
 import type {
   DepositNativeUnwrapOptions,
   DepositNativeWrapOptions,
-  GetDepositAddressDependencies,
   GetDepositServiceDependencies,
+  GetLinkedDepositAddressDependencies,
   SendOptions,
 } from "./types";
 
-export async function getDepositAddress(
+export async function getDepositAddress() {}
+
+export async function getLinkedDepositAddress(
   params: SendOptions,
-  dependencies: GetDepositAddressDependencies
+  dependencies: GetLinkedDepositAddressDependencies
 ) {
   const chainConfigs = await dependencies.configClient.getChainConfigs(
     params.environment

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -32,3 +32,17 @@ export async function getDepositAddress(
 
   return getDepositAddressFromAxelarNetwork(params, chainConfigs, dependencies);
 }
+
+export async function getNativeDepositAddress(
+  params: SendOptions,
+  dependencies: GetDepositAddressDependencies
+) {
+  const chainConfigs = await dependencies.configClient.getChainConfigs(
+    params.environment
+  );
+
+  /**
+   * input validation
+   */
+  validateChainIds([params.sourceChain, params.destinationChain], chainConfigs);
+}

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -53,8 +53,6 @@ export async function getNativeWrapDepositAddress(
     chainConfigs.chains[params.destinationChain.toLowerCase()] as ChainConfig
   );
 
-  console.log("params", params);
-
   const { address } =
     await dependencies.depositServiceClient.getDepositAddressForNativeWrap({
       refundAddress: params.refundAddress,

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -16,9 +16,9 @@ import type {
 
 /**
  * Get the deposit address for a given asset, where:
- * - if the asset is undefined, this function will return deposit address for the native token
- * - if the asset is defined, this function will return the linked deposit address for the asset
- * - if the asset is defined and unwrappable at the destination chain, this function will return the linked deposit address
+ * - if the asset is "native", this function will return deposit address for the native token
+ * - if the asset is not "native" (e.g. "uusdc"), this function will return the linked deposit address for the asset
+ * - if the asset is not "native" (e.g. "uusdc") and unwrappable at the destination chain, this function will return the linked deposit address
  * where the asset is unwrapped first at the destination chain before sending to the destination address.
  * Note: You can skip the unwrap step by setting the `skipUnwrap` option to true.
  * @param params
@@ -42,7 +42,7 @@ export async function getDepositAddress(
   );
 
   // we consider undefined asset as a native token asset
-  if (!asset) {
+  if (asset === "native") {
     // returns the native wrap deposit address
     return getNativeWrapDepositAddress(
       {

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -1,7 +1,7 @@
 import type { ChainConfig } from "@axelarjs/api";
-import { generateRandomHash } from "@axelarjs/utils";
 
 import {
+  generateRandomSalt,
   getDepositAddressFromAxelarNetwork,
   unwrappable,
   validateAddress,
@@ -43,7 +43,7 @@ export async function getDepositAddress(
         sourceChain,
         destinationChain,
         environment,
-        salt: params.options?.salt || generateRandomHash(),
+        salt: params.options?.salt,
         refundAddress: params.options?.refundAddress || destinationAddress,
       },
       dependencies
@@ -69,7 +69,7 @@ export async function getDepositAddress(
           asset,
         },
         dependencies
-      );
+      ).then((res) => res?.depositAddress);
 
     if (shouldUnwrapToken) {
       // the token is unwrappable, we need to get the native unwrap deposit address first.
@@ -85,10 +85,10 @@ export async function getDepositAddress(
         dependencies
       );
 
-      // then, we need to get the linked deposit address based on the unwrapped deposit address
+      // then, we need to get the linked deposit address based on the unwrapped deposit address and return it
       return _getLinkedDepositAddress(unwrappedDepositAddress);
     } else {
-      // the token is not unwrappable, we can get the linked deposit address directly
+      // the token is not unwrappable, we can get the linked deposit address directly and return it
       return _getLinkedDepositAddress(params.destinationAddress);
     }
   }
@@ -139,7 +139,7 @@ export async function getNativeWrapDepositAddress(
       destinationAddress: params.destinationAddress,
       fromChain: params.sourceChain,
       toChain: params.destinationChain,
-      salt: params.salt,
+      salt: params.salt || generateRandomSalt(params.destinationAddress),
     });
 
   return address;

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -14,6 +14,17 @@ import type {
   SendOptions,
 } from "./types";
 
+/**
+ * Get the deposit address for a given asset, where:
+ * - if the asset is undefined, this function will return deposit address for the native token
+ * - if the asset is defined, this function will return the linked deposit address for the asset
+ * - if the asset is defined and unwrappable at the destination chain, this function will return the linked deposit address
+ * where the asset is unwrapped first at the destination chain before sending to the destination address.
+ * Note: You can skip the unwrap step by setting the `skipUnwrap` option to true.
+ * @param params
+ * @param dependencies
+ * @returns
+ */
 export async function getDepositAddress(
   params: DepositAddressOptions,
   dependencies: GetDepositAddressDependencies

--- a/packages/deposit-address/src/get-deposit-address/isomorphic.ts
+++ b/packages/deposit-address/src/get-deposit-address/isomorphic.ts
@@ -1,4 +1,4 @@
-import type { ChainConfig } from "@axelarjs/api";
+import type { /* AxelarEVMChainConfig, */ ChainConfig } from "@axelarjs/api";
 
 import {
   getDepositAddressFromAxelarNetwork,
@@ -7,14 +7,62 @@ import {
   validateChainIds,
 } from "./helpers";
 import type {
+  DepositAddressOptions,
   DepositNativeUnwrapOptions,
   DepositNativeWrapOptions,
+  GetDepositAddressDependencies,
   GetDepositServiceDependencies,
   GetLinkedDepositAddressDependencies,
   SendOptions,
 } from "./types";
 
-export async function getDepositAddress() {}
+export async function getDepositAddress(
+  params: DepositAddressOptions,
+  dependencies: GetDepositAddressDependencies
+) {
+  const chainConfigs = await dependencies.configClient.getChainConfigs(
+    params.environment
+  );
+
+  console.log("==== The following chains has native wrapped asset =====");
+  for (const [k, v] of Object.entries(chainConfigs.chains)) {
+    const nativeWrappedAsset = v.assets.find(
+      (asset) => asset.module === "evm" && asset.isERC20WrappedNativeGasToken
+    );
+    if (nativeWrappedAsset) {
+      console.log(k);
+    }
+  }
+
+  const { asset, sourceChain, destinationChain } = params;
+
+  // const destChainConfig = chainConfigs.chains[
+  //   destinationChain.toLowerCase()
+  // ] as ChainConfig;
+
+  // const srcChainConfig = chainConfigs.chains["arbitrum"] as ChainConfig;
+
+  // if (srcChainConfig.module === "evm" && destChainConfig.module === "evm") {
+  //   const srcEvmChainConfig = srcChainConfig as unknown as AxelarEVMChainConfig;
+  //   const wrappedNativeAsset = srcEvmChainConfig.assets.find((asset) => {
+  //     if (asset.module === "evm" && asset.isERC20WrappedNativeGasToken) {
+  //       return asset;
+  //     }
+  //   });
+  //   if (wrappedNativeAsset) {
+  //     console.log(wrappedNativeAsset);
+  //   } else {
+  //     console.log("not found");
+  //     console.log(srcEvmChainConfig.assets);
+  //   }
+  // }
+
+  if (asset) {
+    validateAsset([sourceChain, destinationChain], asset, chainConfigs);
+  }
+
+  // chainConfigs.chains
+}
 
 export async function getLinkedDepositAddress(
   params: SendOptions,

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -20,7 +20,7 @@ export type DepositAddressOptions = {
   destinationChain: string;
   destinationAddress: string;
   environment: Environment;
-  asset: string; // if not specified, it is the native asset
+  asset: string; // "native" for native token or other identifiers for non-native token e.g. "uusdc", "wavax-wei"
   options?: {
     salt?: string;
     refundAddress?: string;

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -24,6 +24,7 @@ export type DepositAddressOptions = {
   options?: {
     salt?: string;
     refundAddress?: string;
+    skipUnwrap?: boolean;
   };
 };
 

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -2,6 +2,7 @@ import type {
   AxelarConfigClient,
   AxelarscanClient,
   DepositAddressClient,
+  DepositServiceClient,
   GMPClient,
 } from "@axelarjs/api";
 import { type Environment } from "@axelarjs/core";
@@ -14,9 +15,26 @@ export type SendOptions = {
   environment: Environment;
 };
 
+export type DepositNativeWrapOptions = {
+  sourceChain: string;
+  destinationChain: string;
+  destinationAddress: string;
+  refundAddress: string;
+  salt: string;
+  environment: Environment;
+};
+
+export type DepositNativeUnwrapOptions = Omit<DepositNativeWrapOptions, "salt">;
+
 export type GetDepositAddressDependencies = {
   gmpClient: GMPClient;
   depositAddressClient: DepositAddressClient;
   configClient: AxelarConfigClient;
   axelarscanClient: AxelarscanClient;
+};
+
+export type GetDepositServiceDependencies = {
+  gmpClient: GMPClient;
+  configClient: AxelarConfigClient;
+  depositServiceClient: DepositServiceClient;
 };

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -15,6 +15,18 @@ export type SendOptions = {
   environment: Environment;
 };
 
+export type DepositAddressOptions = {
+  sourceChain: string;
+  destinationChain: string;
+  destinationAddress: string;
+  asset: string;
+  options: {
+    salt?: string;
+    refundAddress?: string;
+  };
+  environment: Environment;
+};
+
 export type DepositNativeWrapOptions = {
   sourceChain: string;
   destinationChain: string;
@@ -26,7 +38,7 @@ export type DepositNativeWrapOptions = {
 
 export type DepositNativeUnwrapOptions = Omit<DepositNativeWrapOptions, "salt">;
 
-export type GetDepositAddressDependencies = {
+export type GetLinkedDepositAddressDependencies = {
   gmpClient: GMPClient;
   depositAddressClient: DepositAddressClient;
   configClient: AxelarConfigClient;

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -19,12 +19,12 @@ export type DepositAddressOptions = {
   sourceChain: string;
   destinationChain: string;
   destinationAddress: string;
-  asset: string;
-  options: {
+  environment: Environment;
+  asset?: string; // if not specified, it is the native asset
+  options?: {
     salt?: string;
     refundAddress?: string;
   };
-  environment: Environment;
 };
 
 export type DepositNativeWrapOptions = {
@@ -44,6 +44,11 @@ export type GetLinkedDepositAddressDependencies = {
   configClient: AxelarConfigClient;
   axelarscanClient: AxelarscanClient;
 };
+
+export type GetDepositAddressDependencies =
+  GetLinkedDepositAddressDependencies & {
+    depositServiceClient: DepositServiceClient;
+  };
 
 export type GetDepositServiceDependencies = {
   gmpClient: GMPClient;

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -32,7 +32,7 @@ export type DepositNativeWrapOptions = {
   destinationChain: string;
   destinationAddress: string;
   refundAddress: string;
-  salt: string;
+  salt?: string | undefined;
   environment: Environment;
 };
 

--- a/packages/deposit-address/src/get-deposit-address/types.ts
+++ b/packages/deposit-address/src/get-deposit-address/types.ts
@@ -20,7 +20,7 @@ export type DepositAddressOptions = {
   destinationChain: string;
   destinationAddress: string;
   environment: Environment;
-  asset?: string; // if not specified, it is the native asset
+  asset: string; // if not specified, it is the native asset
   options?: {
     salt?: string;
     refundAddress?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,8 +475,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@axelarjs/cosmos':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../cosmos
+      '@axelarjs/proto':
+        specifier: workspace:*
+        version: link:../proto
       '@axelarjs/utils':
         specifier: workspace:*
         version: link:../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
         specifier: ^5.2.3
         version: 5.2.3
     devDependencies:
+      '@axelarjs/core':
+        specifier: workspace:*
+        version: link:../core
       '@tsconfig/strictest':
         specifier: ^2.0.2
         version: 2.0.2
@@ -471,6 +474,9 @@ importers:
       '@axelarjs/core':
         specifier: workspace:*
         version: link:../core
+      '@axelarjs/cosmos':
+        specifier: workspace:^
+        version: link:../cosmos
       '@axelarjs/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
# Description

This PR added support for wrap/unwrap deposit address generation.

## Changes

- Added `getNativeWrapDepositAddress` API
- Added `getNativeUnwrapDepositAddress` API
- Renamed `getDepositAddress` to `getLinkedDepositAddress`
- Added the new `getDepositAddress` API. This function will return the deposit address based on three scenarios:
   - The source token is native token, then this function returns deposit address from the `getNativeWrapDepositAddress` function.
   - The source token is not native token and the associated `asset` on the destination chain has `isERC20WrappedNativeGasToken = true`, then this function will return the linked deposit address where the destination address for linked deposit address is unwrap deposit address. (there're two addresses generation)
   - The source token is not native token and `isERC20WrappedNativeGasToken` is falsy, then the function simply returns the linked deposit address
   
 ## Todo
 - [x] ~~Validate the wrap/unwrap addresses offline to prevent man in the middle attack~~ Skip
 - [x] Validate if given chains are active
 - [x] Manually check on testnet if those addresses from 3 cases are working properly.
 
## Test Results
 
### 1. Native Wrap Address

Sending AVAX from Avalanche to Fantom should receive WAVAX at the destination chain

#### Parameters
```ts
{
  sourceChain: "Avalanche",
  destinationChain: "Fantom",
  destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC"
}
```

#### Returned Address

`0xcd780367774c6ff9d781f41b09a095c450ecda58`

#### Test Result
Passed ✅

[Avalanche Tx](https://testnet.snowtrace.io/tx/0x970835a0b6d99a2d37a10958fa9918b1e6855ecfcff221ca97420efcfa39b1f7)
[Axelarscan Tx](https://testnet.axelarscan.io/transfer/0x988c19c553cdd31c1e4cd9496c6d4309e7c30ea36fa673a4713a6c04714b87ac)
[Fantom Tx](https://testnet.ftmscan.com/tx/0x3d568ed93b96cbb4d8eac16562128d43cf615d364e3a232d95ce295bf2aa8a7c)

### 2. Unwrap Address

Sending WFTM from Avalanche to Fantom should receive FTM at the destination chain

#### Parameters
```ts
{
     sourceChain: "Avalanche",
     destinationChain: "Fantom",
     asset: "wftm-wei",
     destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
}
```

#### Returned Address

`0x7C74188B53193E2513C707F26d1Ecf6d0d2765B4`

#### Test Results

Passed ✅

[Avalanche Tx](https://testnet.snowtrace.io/tx/0xe729fe538b4a8afbd621f4a4bfd0d2abe01779e708cffd8c7dae6ee6ff73f635?chainId=43113)
Axelarscan Tx not found
[Fantom Tx](https://testnet.ftmscan.com/tx/0x955e5c91daa424b5990ad6d55e19cdd657207f77aa085ce84af9f9820cc7cad6)

### 3. Simple Linked Address

Sending aUSDC from Avalanche to Fantom should receive aUSDC at the destination chain

#### Parameters
```ts
{
    sourceChain: "Avalanche",
    destinationChain: "Fantom",
    asset: "uasdc",
    destinationAddress: "0xB8Cd93C83A974649D76B1c19f311f639e62272BC"
}
```

#### Returned Address

`0xE12F77E36745Ad1019fbd19d09f2491047f9Ee73`

#### Test Result

Passed ✅

[Avalanche Tx](https://testnet.snowtrace.io/tx/0x0fe8b77414c5e296ab9b90763dc2a8a1ce0a3a5d76ede716e15f4057704b285c?chainId=43113)
Axelarscan Tx not found
[Fantom Tx](https://testnet.ftmscan.com/tx/0x17a0e9af1c49ea0769c819b3a6507a241ce94ea84121f58ca8928815e988d226)