### PR TITLE
fix: "RangeError: Division by zero" error

### DIFF
--- a/packages/api/src/axelar-query/utils/bigint.spec.ts
+++ b/packages/api/src/axelar-query/utils/bigint.spec.ts
@@ -1,0 +1,8 @@
+import { gasToWei } from "./bigint";
+
+describe("bigint", () => {
+  test("should work even gas_price has more fractional digits than specified decimals", () => {
+    const wei = gasToWei(1000000n, "0.00000001", 6);
+    expect(wei).toBe(10000n);
+  });
+});

--- a/packages/api/src/axelar-query/utils/bigint.ts
+++ b/packages/api/src/axelar-query/utils/bigint.ts
@@ -23,14 +23,16 @@ export function gasToWei(
   decimals: number
 ): bigint {
   // Split the gasPrice into integer and fractional parts
-  const [integerPart, fractionalPart = ""] = gasPrice.split(".");
+  const fractionalPart = gasPrice.split(".")[1] || "";
 
-  // Adjust the gasPrice to the desired precision using a ternary operation
-  const adjustedGasPrice =
-    fractionalPart.length <= decimals
-      ? gasPrice
-      : `${integerPart}.${fractionalPart.substring(0, decimals)}`;
-
-  // Calculate the total cost in wei
-  return gasLimit * BigInt(parseUnits(adjustedGasPrice, decimals));
+  if (fractionalPart.length <= decimals) {
+    return gasLimit * BigInt(parseUnits(gasPrice, decimals));
+  } else {
+    const multiplier = Math.pow(10, decimals);
+    const multipliedGasPrice = Number(gasPrice) * multiplier;
+    return (
+      (gasLimit * parseUnits(multipliedGasPrice.toFixed(decimals), decimals)) /
+      BigInt(multiplier)
+    );
+  }
 }


### PR DESCRIPTION
This PR fixes an error `RangeError: Division by zero` when trying to estimate gas for tx that sending from `evm chain` to `cosmos chain`