### PR TITLE
fix: floating points error

### DIFF
--- a/apps/maestro/src/features/ManageInterchainToken/actions/mint/MintInterchainToken.tsx
+++ b/apps/maestro/src/features/ManageInterchainToken/actions/mint/MintInterchainToken.tsx
@@ -4,7 +4,7 @@ import { invariant } from "@axelarjs/utils";
 import { useMemo, type FC } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 
-import { TransactionExecutionError } from "viem";
+import { parseUnits, TransactionExecutionError } from "viem";
 import { useChainId } from "wagmi";
 
 import { logger } from "~/lib/logger";
@@ -35,8 +35,10 @@ export const MintInterchainToken: FC = () => {
   const submitHandler: SubmitHandler<FormState> = async (data, e) => {
     e?.preventDefault();
 
-    const decimalAdjustment = 10n ** BigInt(erc20Details?.decimals ?? 18n);
-    const adjustedAmount = BigInt(data.amountToMint) * decimalAdjustment;
+    const adjustedAmount = parseUnits(
+      data.amountToMint,
+      erc20Details?.decimals || 18
+    );
 
     setTxState({
       status: "awaiting_approval",


### PR DESCRIPTION
# Description

[AXE-3058](https://axelarnetwork.atlassian.net/browse/AXE-3058?atlOrigin=eyJpIjoiOWIwZGM4ZTU1MzAzNGI0MWE1NzlhZmE5ZjhkMjEyYTEiLCJwIjoiaiJ9)

Fix error when trying to mint token with amount with floating points. `parseUnits` function from viem basically handles this.

![image](https://github.com/axelarnetwork/axelarjs/assets/78221556/c862091a-9842-416a-a699-2fc095967da4)


[AXE-3058]: https://axelarnetwork.atlassian.net/browse/AXE-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ