### PR TITLE
chore: add condition to showing finality progess bar

### DIFF
--- a/apps/maestro/src/features/Transactions/Transactions.tsx
+++ b/apps/maestro/src/features/Transactions/Transactions.tsx
@@ -100,6 +100,10 @@ const ToastElement: FC<ToastElementProps> = ({
     [computed.wagmiChains, chainId]
   );
 
+  const showFinalityProgressBar =
+    groupedStatusesProps.some((group) => group.status === "called") &&
+    elapsedBlocks < expectedConfirmations;
+
   const content = (
     <>
       <div className="flex items-center">
@@ -121,7 +125,7 @@ const ToastElement: FC<ToastElementProps> = ({
         </Tooltip>
         <div className="mx-2 flex flex-col items-start">
           <span className="text-sm">{txTypeText}</span>
-          {elapsedBlocks < expectedConfirmations ? (
+          {showFinalityProgressBar ? (
             <Tooltip
               tip={`Waiting for finality on ${computed.indexedByChainId[chainId]?.name}`}
               position="top"

--- a/apps/maestro/src/ui/compounds/GMPTxStatusMonitor/GMPTxStatusMonitor.tsx
+++ b/apps/maestro/src/ui/compounds/GMPTxStatusMonitor/GMPTxStatusMonitor.tsx
@@ -159,6 +159,10 @@ const GMPTxStatusMonitor = ({ txHash, onAllChainsExecuted }: Props) => {
     );
   }
 
+  const showFinalityProgressBar = statusList.some(
+    (chain) => chain.status === "called"
+  );
+
   return (
     <div className="grid gap-4">
       <div className="flex items-center justify-between">
@@ -168,7 +172,9 @@ const GMPTxStatusMonitor = ({ txHash, onAllChainsExecuted }: Props) => {
           </span>
         )}
       </div>
-      <TxFinalityProgress txHash={txHash} chainId={chainId} />
+      {showFinalityProgressBar && (
+        <TxFinalityProgress txHash={txHash} chainId={chainId} />
+      )}
       <ul className="bg-base-300 rounded-box grid gap-2 p-4">
         {[...Object.entries(statuses ?? {})].map(
           ([axelarChainId, { status, logIndex }]) => {


### PR DESCRIPTION
Right now, the progress bars appear if current num confirmations < expected. Also adding a condition to hide the progress bar if the tx has already been confirmed.