### PR TITLE
chore: fix search results to center lookup token to origin token

### DIFF
--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -106,15 +106,21 @@ async function getInterchainToken(
   remainingChainConfigs: ExtendedWagmiChainConfig[],
   ctx: Context
 ) {
+  const originChain =
+    tokenDetails.axelarChainId === chainConfig?.axelarChainId
+      ? chainConfig
+      : remainingChainConfigs.find(
+          (chain) => chain.axelarChainId === tokenDetails.axelarChainId
+        );
   const lookupToken = {
     tokenId: tokenDetails.tokenId,
     tokenAddress: tokenDetails.tokenAddress,
     tokenManagerAddress: tokenDetails.tokenManagerAddress,
     tokenManagerType: tokenDetails.tokenManagerType,
-    isOriginToken: tokenDetails.axelarChainId === chainConfig?.axelarChainId,
+    isOriginToken: true,
     isRegistered: true,
-    chainId: chainConfig.id,
-    chainName: chainConfig.name,
+    chainId: originChain?.id,
+    chainName: originChain?.name,
     axelarChainId: tokenDetails.axelarChainId,
     kind: tokenDetails.kind,
   };


### PR DESCRIPTION
this fix addresses the following steps to reproduce:

1. for this token page: https://testnet.interchain.axelar.dev/avalanche/0x88a0cccD4Bcfd55Ff9D11f68023acF7192bf6694, you see that address on polygon is 0x7748FEAD09B1aD139Fe979Ed54E8652BC811A13d
2. open a new window and switch your wallet to polygon, then search for 0x7748FEAD09B1aD139Fe979Ed54E8652BC811A13d
3. you'll see that there isn't an origin token listed, and you can't transfer to any other chain.