### PR TITLE
chore: its portal changelog

### DIFF
--- a/.changeset/lucky-coins-explode.md
+++ b/.changeset/lucky-coins-explode.md
@@ -1,0 +1,11 @@
+---
+"@axelarjs/maestro": patch
+---
+
+feat: added blast and fraxtal mainnet https://github.com/axelarnetwork/axelarjs/compare/%40axelarjs/maestro%400.3.4...main
+feat: added l2 sepolia testnets https://github.com/axelarnetwork/axelarjs/commit/9665458984f9994fdc24c43424245b4e37d30731
+feat: posted final results for its competition (https://github.com/axelarnetwork/axelarjs/commit/6473340dcb417abc6badda0d2dc559b792dc5c7f, https://github.com/axelarnetwork/axelarjs/commit/6c586fb29185e85ed1739d698e3555a58afb8419)
+fix: fix for canonical token id lookup https://github.com/axelarnetwork/axelarjs/commit/0e631079e7ab5b5c50888623367ff2bbf14d8043
+fix: validation on token logo upload https://github.com/axelarnetwork/axelarjs/commit/d1d9f477f5638cda5236ed28ec0562a79fec42ee
+fix: allow token deployer to deploy icon (vs. only a designated "minter" was only allowed before) https://github.com/axelarnetwork/axelarjs/commit/f6f74400d007358c6e5a7b019100a07d9dae19f3
+fix: tx status indicator not showing pending transaction on click https://github.com/axelarnetwork/axelarjs/commit/0336678d27beabe415369c8ffec6b8cba2e5d911


### PR DESCRIPTION
* generated from running `npm run changeset` from the root directory of the repo
* from the `lucky-coins-explode.md` file, manually entered all changes by looking at this diff: https://github.com/axelarnetwork/axelarjs/compare/%40axelarjs/maestro%400.3.4...main