### PR TITLE
feat: add whitelist token on squid link

### DIFF
--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
@@ -87,6 +87,25 @@ const TokenDetailsSection: FC<TokenDetailsSectionProps> = (props) => {
           </LinkButton>
         ),
       ],
+      [
+        "Whitelisting Your Token at Squid",
+        props.wasDeployedByAccount && (
+          <Tooltip
+            $as={Indicator}
+            $position="right"
+            tip="Use the wizard in the repo to whitelist your token. You can then add the Squid widget to your user interface, which will allow you to bridge your Interchain Token after it has been whitelisted"
+          >
+            <LinkButton
+              target="_blank"
+              className="ml-[-10px]"
+              $variant="link"
+              href="https://github.com/axelarnetwork/axelar-configs "
+            >
+              Link
+            </LinkButton>
+          </Tooltip>
+        ),
+      ],
     ]),
     ...Maybe.of(props.tokenManagerAddress).mapOr([], (tokenManagerAddress) => [
       [


### PR DESCRIPTION
[AXE-3626](https://axelarnetwork.atlassian.net/browse/AXE-3626)

Closes https://github.com/axelarnetwork/axelarjs/issues/275

![image](https://github.com/axelarnetwork/axelarjs/assets/78221556/7d1716e4-8f52-49a6-b444-343d82f92fac)
The popup shows when the cursor is hovering over the link. I temporarily simply added the link here for now. I'll think more about better places since there're more cta to be added.

[AXE-3626]: https://axelarnetwork.atlassian.net/browse/AXE-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ