### PR TITLE
chore: exclude src chain from "chains to claim token ownership" field

### DIFF
--- a/apps/maestro/src/lib/utils/gform.ts
+++ b/apps/maestro/src/lib/utils/gform.ts
@@ -25,15 +25,16 @@ export function getPrefilledClaimOwnershipFormLink(
   tokenType: string,
   tokenAddress: string
 ) {
+  const srcChain = sourceChain.toLowerCase();
   const formLink = NEXT_PUBLIC_CLAIM_OWNERSHIP_FORM_LINK;
   const formFields = {
-    [ClaimOwnershipFormFieldIds.sourceChain]: sourceChain,
+    [ClaimOwnershipFormFieldIds.sourceChain]: chainIdToGFormChainId[srcChain],
     [ClaimOwnershipFormFieldIds.tokenType]: tokenType,
     [ClaimOwnershipFormFieldIds.tokenAddress]: tokenAddress,
   };
 
   const destChainsParams: string[] = allChains
-    .filter((chain) => chainIdToGFormChainId[chain] && chain !== sourceChain)
+    .filter((chain) => chainIdToGFormChainId[chain] && chain !== srcChain)
     .map(
       (chain) =>
         `${ClaimOwnershipFormFieldIds.allChains}=${chainIdToGFormChainId[chain]}`

--- a/apps/maestro/src/lib/utils/gform.ts
+++ b/apps/maestro/src/lib/utils/gform.ts
@@ -6,7 +6,7 @@ import {
 const chainIdToGFormChainId = {
   arbitrum: "Arbitrum",
   base: "Base",
-  binance: "Binance Smart Chain(BSC)",
+  binance: "BNB Chain",
   celo: "Celo",
   ethereum: "Ethereum",
   fantom: "Fantom",

--- a/apps/maestro/src/lib/utils/gform.ts
+++ b/apps/maestro/src/lib/utils/gform.ts
@@ -17,6 +17,10 @@ const chainIdToGFormChainId = {
   scroll: "Scroll",
   blast: "Blast",
   fraxtal: "Fraxtal",
+  avalanche: "Avalanche",
+  kava: "Kava",
+  filecoin: "Filecoin",
+  mantle: "Mantle",
 } as any;
 
 export function getPrefilledClaimOwnershipFormLink(

--- a/apps/maestro/src/lib/utils/gform.ts
+++ b/apps/maestro/src/lib/utils/gform.ts
@@ -15,6 +15,8 @@ const chainIdToGFormChainId = {
   optimism: "Optimism",
   polygon: "Polygon",
   scroll: "Scroll",
+  blast: "Blast",
+  fraxtal: "Fraxtal",
 } as any;
 
 export function getPrefilledClaimOwnershipFormLink(
@@ -31,7 +33,7 @@ export function getPrefilledClaimOwnershipFormLink(
   };
 
   const destChainsParams: string[] = allChains
-    .filter((chain) => chainIdToGFormChainId[chain])
+    .filter((chain) => chainIdToGFormChainId[chain] && chain !== sourceChain)
     .map(
       (chain) =>
         `${ClaimOwnershipFormFieldIds.allChains}=${chainIdToGFormChainId[chain]}`

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
@@ -40,7 +40,7 @@ export type TokenDetailsSectionProps = {
   tokenId?: `0x${string}` | null | undefined;
   tokenManagerAddress?: `0x${string}` | null;
   kind?: "canonical" | "interchain" | "custom";
-  claimOwnershipFormLink: string;
+  claimOwnershipFormLink?: string;
 };
 
 const TokenDetailsSection: FC<TokenDetailsSectionProps> = (props) => {
@@ -88,7 +88,7 @@ const TokenDetailsSection: FC<TokenDetailsSectionProps> = (props) => {
           </Tooltip>
         </div>,
       ],
-      [
+      props.claimOwnershipFormLink && [
         "Token Ownership Claim Request",
         props.wasDeployedByAccount && (
           <LinkButton

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
@@ -88,9 +88,9 @@ const TokenDetailsSection: FC<TokenDetailsSectionProps> = (props) => {
           </Tooltip>
         </div>,
       ],
-      props.claimOwnershipFormLink && [
+      [
         "Token Ownership Claim Request",
-        props.wasDeployedByAccount && (
+        props.wasDeployedByAccount && props.claimOwnershipFormLink && (
           <LinkButton
             target="_blank"
             className="ml-[-10px]"

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/index.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/index.tsx
@@ -43,6 +43,10 @@ const InterchainTokensPage: FC = () => {
       ?.filter((token) => token.isRegistered)
       ?.map((token) => token.axelarChainId) || [];
 
+  const destToken = interchainToken.matchingTokens?.find(
+    (token) => !token.isOriginToken
+  );
+
   return (
     <Page
       pageTitle={`Interchain Tokens - ${routeChain?.name}`}
@@ -61,12 +65,15 @@ const InterchainTokensPage: FC = () => {
           tokenId={interchainToken?.tokenId}
           tokenManagerAddress={interchainToken?.tokenManagerAddress}
           kind={interchainToken?.kind}
-          claimOwnershipFormLink={getPrefilledClaimOwnershipFormLink(
-            interchainToken.chain.name,
-            chainNames,
-            "Interchain Token Service (ITS)",
-            tokenAddress
-          )}
+          claimOwnershipFormLink={
+            destToken &&
+            getPrefilledClaimOwnershipFormLink(
+              interchainToken.chain.name,
+              chainNames,
+              "Interchain Token Service (ITS)",
+              destToken.tokenAddress as string
+            )
+          }
         />
       )}
       {routeChain && tokenDetails && (

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/index.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/index.tsx
@@ -43,8 +43,6 @@ const InterchainTokensPage: FC = () => {
       ?.filter((token) => token.isRegistered)
       ?.map((token) => token.axelarChainId) || [];
 
-  console.log("Chain Names", chainNames);
-
   return (
     <Page
       pageTitle={`Interchain Tokens - ${routeChain?.name}`}


### PR DESCRIPTION
# Description

- Excluded src chain from being auto-filled in `Chains to claim token ownership on` section (the image below)
- Mapped src chain name to the form value

![image](https://github.com/axelarnetwork/axelarjs/assets/78221556/e9d2a3b6-0042-458a-8564-43cb675125fc)


