### PR TITLE
feat: add query transaction status

### DIFF
--- a/.changeset/eight-nails-hunt.md
+++ b/.changeset/eight-nails-hunt.md
@@ -1,0 +1,6 @@
+---
+"@axelarjs/transaction-recovery": patch
+"@axelarjs/api": patch
+---
+
+chore: add queryTransactionStatus to transaction-recovery package

--- a/packages/api/src/gmp/types.ts
+++ b/packages/api/src/gmp/types.ts
@@ -54,7 +54,7 @@ export type ContractMethod = (typeof VALID_CONTRACT_METHODS)[number];
 
 export type SearchGMPParams = Omit<BaseGMPParams, "contractMethod"> & {
   contractMethod?: ContractMethod[] | ContractMethod;
-  txHash?: `0x${string}`;
+  txHash: string;
   txLogIndex?: number | undefined;
   messageId?: string | undefined;
   status?: GMPTxStatus;
@@ -74,7 +74,7 @@ type HexAmount = {
   hex: string;
 };
 
-type SearchGMPCall = {
+export type SearchGMPCall = {
   blockNumber: number;
   blockHash: `0x${string}`;
   block_timestamp: number;
@@ -122,7 +122,7 @@ type SearchGMPTransaction = {
   hash: string;
 };
 
-type SearchGMPExecuted = {
+export type SearchGMPExecuted = {
   chain: string;
   sourceTransactionIndex: number;
   sourceChain: string;
@@ -179,25 +179,36 @@ type SearchGMPFees = {
     express_gas_overhead_fee: number;
   };
 };
+
+export type SearchGMPApprove = {
+  transactionHash: string;
+  contract_address: string;
+  chain: string;
+  chain_type: string;
+};
+
 export type SearchGMPGasStatus =
   | "gas_paid"
   | "gas_paid_not_enough_gas"
   | "gas_unpaid"
   | "gas_paid_enough_gas";
+
+type GMPTxCreatedAt = {
+  week: number;
+  hour: number;
+  month: number;
+  year: number;
+  ms: number;
+  day: number;
+  quarter: number;
+};
+
 export type SearchGMPGasPaid = {
   axelarTransactionHash: string;
   chain: string;
   chain_type: string;
   logIndex: number;
-  createdAt: {
-    week: number;
-    hour: number;
-    month: number;
-    year: number;
-    ms: number;
-    day: number;
-    quarter: number;
-  };
+  created_at: GMPTxCreatedAt;
   transactionHash: string;
   returnValues: {
     refundAddress: string;
@@ -259,15 +270,39 @@ export type SearchGMPResponseData = {
   fees: SearchGMPFees;
   status: GMPTxStatus;
   executed?: SearchGMPExecuted;
+  error?: SearchGMPDataError;
+  time_spent: number;
   gas_paid: SearchGMPGasPaid;
   gas_status: SearchGMPGasStatus;
+  express_executed?: SearchGMPExecuted;
+  express_executing_at?: number;
+  approved: SearchGMPApprove;
   command_id?: string;
   is_invalid_destination_chain: boolean;
   is_call_from_relayer: boolean;
   is_invalid_call: boolean;
+  is_insufficient_fee: boolean;
   interchain_transfer?: InterchainTransferEvent;
   interchain_token_deployment_started?: InterchainTokenDeploymentStartedEvent;
   token_manager_deployment_started?: TokenManagerDeploymentStartedEvent;
+};
+
+export type SearchGMPExpressExecuted = {
+  sourceChain: string;
+  chain: string;
+  created_at: GMPTxCreatedAt;
+};
+
+export type SearchGMPDataError = {
+  chain: string;
+  sourceChain: string;
+  chain_type: string;
+  messageId: string;
+  error: {
+    reason: string;
+    message: string;
+    transactionHash: string;
+  };
 };
 
 export type SearchGMPResponse = BaseGMPResponse<{

--- a/packages/api/src/gmp/types.ts
+++ b/packages/api/src/gmp/types.ts
@@ -274,7 +274,7 @@ export type SearchGMPResponseData = {
   time_spent: number;
   gas_paid: SearchGMPGasPaid;
   gas_status: SearchGMPGasStatus;
-  express_executed?: SearchGMPExecuted;
+  express_executed?: SearchGMPExpressExecuted;
   express_executing_at?: number;
   approved: SearchGMPApprove;
   command_id?: string;

--- a/packages/api/src/gmp/types.ts
+++ b/packages/api/src/gmp/types.ts
@@ -271,7 +271,7 @@ export type SearchGMPResponseData = {
   status: GMPTxStatus;
   executed?: SearchGMPExecuted;
   error?: SearchGMPDataError;
-  time_spent: number;
+  time_spent: SearchGMPTimespent;
   gas_paid: SearchGMPGasPaid;
   gas_status: SearchGMPGasStatus;
   express_executed?: SearchGMPExpressExecuted;
@@ -285,6 +285,14 @@ export type SearchGMPResponseData = {
   interchain_transfer?: InterchainTransferEvent;
   interchain_token_deployment_started?: InterchainTokenDeploymentStartedEvent;
   token_manager_deployment_started?: TokenManagerDeploymentStartedEvent;
+};
+
+export type SearchGMPTimespent = {
+  call_express_executed?: number;
+  call_confirm?: number;
+  call_approve?: number;
+  approved_executed?: number;
+  total: number;
 };
 
 export type SearchGMPExpressExecuted = {

--- a/packages/transaction-recovery/src/query-transaction-status/client.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/client.ts
@@ -1,0 +1,30 @@
+import { createGMPClient } from "@axelarjs/api/gmp";
+
+import { queryTransactionStatus as baseQueryTransactionStatus } from "./isomorphic";
+import type { QueryTransactionStatusParams } from "./types";
+
+/**
+ * Send additional native gas to the source transaction to cover the insufficient gas fee.
+ * This function will calculate the amount that needs to be paid additionally and send the transaction to pay the native gas to the AxelarGasService contract.
+ * The default sender wallet is browser-based wallet (window.ethereum), but it can be overridden by providing the private key.
+ * @param params - The parameters to send additional native gas. the parameters are:
+ * - `txHash`: The hash of the source transaction.
+ * - `chain`: The source chain of the transaction.
+ * - `estimatedGasUsed`: The estimated gas used to execute transaction on the destination chain.
+ * - `addNativeGasOptions` (Optional): The options to send the transaction. The options are:
+ *  - `amount` (Optional): The amount of native gas to be paid. If not provided, the amount will be calculated based on the estimated gas used and the gas multiplier.
+ *  - `gasMultiplier` (Optional): The multiplier to calculate the amount of native gas to be paid. If not provided, the api will use the pre-calculated value.
+ *  - `privateKey` (Optional): The private key of the sender. If not provided, the api will use the connected sender on browser-based wallet.
+ *  - `refundAddress` (Optional): The address to refund the native gas if there's any remaining after execution. If not provided, the api will use the sender address.
+ *  - `rpcUrl` (Optional): The RPC URL of the source chain. if not provided, the api will use the RPC URL from the chain configuration.
+ * @returns The native gas payment transaction.
+ */
+export function queryTransactionStatus(params: QueryTransactionStatusParams) {
+  const { environment } = params;
+
+  return baseQueryTransactionStatus(params, {
+    gmpClient: createGMPClient(environment),
+  });
+}
+
+export default queryTransactionStatus;

--- a/packages/transaction-recovery/src/query-transaction-status/client.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/client.ts
@@ -1,25 +1,21 @@
 import { createGMPClient } from "@axelarjs/api/gmp";
 
 import { queryTransactionStatus as baseQueryTransactionStatus } from "./isomorphic";
-import type { QueryTransactionStatusParams } from "./types";
+import type {
+  QueryTransactionStatusParams,
+  QueryTransactionStatusResult,
+} from "./types";
 
 /**
- * Send additional native gas to the source transaction to cover the insufficient gas fee.
- * This function will calculate the amount that needs to be paid additionally and send the transaction to pay the native gas to the AxelarGasService contract.
- * The default sender wallet is browser-based wallet (window.ethereum), but it can be overridden by providing the private key.
- * @param params - The parameters to send additional native gas. the parameters are:
+ * Query the status of the transaction sent to the destination chain.
+ * @param params - The parameters to query the transaction status. The parameters are:
  * - `txHash`: The hash of the source transaction.
- * - `chain`: The source chain of the transaction.
- * - `estimatedGasUsed`: The estimated gas used to execute transaction on the destination chain.
- * - `addNativeGasOptions` (Optional): The options to send the transaction. The options are:
- *  - `amount` (Optional): The amount of native gas to be paid. If not provided, the amount will be calculated based on the estimated gas used and the gas multiplier.
- *  - `gasMultiplier` (Optional): The multiplier to calculate the amount of native gas to be paid. If not provided, the api will use the pre-calculated value.
- *  - `privateKey` (Optional): The private key of the sender. If not provided, the api will use the connected sender on browser-based wallet.
- *  - `refundAddress` (Optional): The address to refund the native gas if there's any remaining after execution. If not provided, the api will use the sender address.
- *  - `rpcUrl` (Optional): The RPC URL of the source chain. if not provided, the api will use the RPC URL from the chain configuration.
- * @returns The native gas payment transaction.
+ * - `environment`: The environment to query the transaction status. The value can be `mainnet`, `testnet`.
+ * @returns see {@link QueryTransactionStatusResult}
  */
-export function queryTransactionStatus(params: QueryTransactionStatusParams) {
+export function queryTransactionStatus(
+  params: QueryTransactionStatusParams
+): Promise<QueryTransactionStatusResult> {
   const { environment } = params;
 
   return baseQueryTransactionStatus(params, {

--- a/packages/transaction-recovery/src/query-transaction-status/index.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/index.ts
@@ -1,0 +1,2 @@
+export * from "./client";
+export * from "./types";

--- a/packages/transaction-recovery/src/query-transaction-status/isomorphic.spec.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/isomorphic.spec.ts
@@ -1,0 +1,64 @@
+import { queryTransactionStatus } from "./client";
+
+describe("queryTransactionStatus", () => {
+  const environment = "mainnet";
+
+  test("should return success false when the tx is not found", async () => {
+    const txHash = "0x1234567890";
+    const result = await queryTransactionStatus({
+      txHash,
+      environment,
+    });
+
+    expect(result.success).toEqual(false);
+    expect(result.error).toEqual("Transaction not found");
+  });
+
+  test("should return success true when the given tx hash for cosmos tx exists", async () => {
+    const txHash =
+      "A08331DC2FCA287B96D8F93C9FAA34A9C90BFA48A1D1A230108B7F563925AA8F";
+    const result = await queryTransactionStatus({
+      txHash,
+      environment,
+    });
+    expect(result.success).toEqual(true);
+    expect(result.data?.status).toBeDefined();
+    expect(result.data?.timeSpent).toBeDefined();
+    expect(result.data?.gasPaidInfo).toBeDefined();
+    expect(result.data?.callTx).toBeDefined();
+    expect(result.data?.executed).toBeDefined();
+
+    const resultForLowerCaseTxHash = await queryTransactionStatus({
+      txHash: txHash.toLowerCase(),
+      environment,
+    });
+    expect(resultForLowerCaseTxHash.success).toEqual(true);
+  });
+
+  test("should return success true when the given tx hash for evm tx exists", async () => {
+    const txHash =
+      "0x9d396b11115455ffdf32294915ccfb12e3ae48e7c89f85e1f3fc6bfb591d1a3e";
+    const result = await queryTransactionStatus({
+      txHash,
+      environment,
+    });
+    expect(result.success).toEqual(true);
+    expect(result.data?.status).toBeDefined();
+    expect(result.data?.timeSpent).toBeDefined();
+    expect(result.data?.gasPaidInfo).toBeDefined();
+    expect(result.data?.callTx).toBeDefined();
+    expect(result.data?.executed).toBeDefined();
+  });
+
+  test("should return expressExecuted and expressExecutedAt when the given tx hash is express tx", async () => {
+    const txHash =
+      "0xac8b22c4ae0890832adcbca19f8bfd0db734a6bf00a99fe839ca6d1055b9942b";
+    const result = await queryTransactionStatus({
+      txHash,
+      environment,
+    });
+    expect(result.success).toEqual(true);
+    expect(result.data?.expressExecuted).toBeDefined();
+    expect(result.data?.expressExecutedAt).toBeDefined();
+  });
+});

--- a/packages/transaction-recovery/src/query-transaction-status/isomorphic.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/isomorphic.ts
@@ -1,0 +1,74 @@
+import type { SearchGMPResponseData } from "@axelarjs/api";
+
+import type {
+  QueryTransactionStatusDependencies,
+  QueryTransactionStatusError,
+  QueryTransactionStatusParams,
+} from "./types";
+
+function parseTxError(
+  firstTx: SearchGMPResponseData
+): QueryTransactionStatusError | undefined {
+  const errorDetails = firstTx.error;
+  if (errorDetails) {
+    return {
+      message: errorDetails.error.message,
+      txHash: errorDetails.error.transactionHash,
+      chain: errorDetails.chain,
+    };
+  } else if (firstTx.is_insufficient_fee) {
+    return {
+      message: "Insufficient fee",
+      txHash: firstTx.call.transactionHash,
+      chain: firstTx.call.chain,
+    };
+  }
+
+  return undefined;
+}
+
+export async function queryTransactionStatus(
+  params: QueryTransactionStatusParams,
+  dependencies: QueryTransactionStatusDependencies
+) {
+  const { txHash, txLogIndex } = params;
+  const { gmpClient } = dependencies;
+
+  const txs = await gmpClient.searchGMP({
+    txHash,
+    txLogIndex,
+  });
+
+  if (txs.length === 0) {
+    return {
+      status: "transaction not found",
+    };
+  }
+
+  const firstTx = txs[0]!;
+
+  const {
+    call,
+    status,
+    gas_status,
+    gas_paid,
+    executed,
+    express_executed,
+    approved,
+    time_spent,
+  } = firstTx;
+
+  return {
+    status,
+    error: parseTxError(firstTx),
+    timeSpent: time_spent,
+    gasPaidInfo: {
+      status: gas_status,
+      details: gas_paid,
+    },
+    callTx: call,
+    executed,
+    expressExecuted: express_executed,
+    approved,
+  };
+}

--- a/packages/transaction-recovery/src/query-transaction-status/isomorphic.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/isomorphic.ts
@@ -4,6 +4,7 @@ import type {
   QueryTransactionStatusDependencies,
   QueryTransactionStatusError,
   QueryTransactionStatusParams,
+  QueryTransactionStatusResult,
 } from "./types";
 
 function parseTxError(
@@ -30,7 +31,7 @@ function parseTxError(
 export async function queryTransactionStatus(
   params: QueryTransactionStatusParams,
   dependencies: QueryTransactionStatusDependencies
-) {
+): Promise<QueryTransactionStatusResult> {
   const { txHash, txLogIndex } = params;
   const { gmpClient } = dependencies;
 
@@ -41,7 +42,8 @@ export async function queryTransactionStatus(
 
   if (txs.length === 0) {
     return {
-      status: "transaction not found",
+      success: false,
+      error: "Transaction not found",
     };
   }
 
@@ -53,22 +55,27 @@ export async function queryTransactionStatus(
     gas_status,
     gas_paid,
     executed,
-    express_executed,
-    approved,
     time_spent,
+    express_executed,
+    express_executing_at,
+    approved,
   } = firstTx;
 
   return {
-    status,
-    error: parseTxError(firstTx),
-    timeSpent: time_spent,
-    gasPaidInfo: {
-      status: gas_status,
-      details: gas_paid,
+    success: true,
+    data: {
+      status,
+      error: parseTxError(firstTx),
+      timeSpent: time_spent,
+      gasPaidInfo: {
+        status: gas_status,
+        details: gas_paid,
+      },
+      callTx: call,
+      executed,
+      expressExecuted: express_executed,
+      expressExecutedAt: express_executing_at,
+      approved,
     },
-    callTx: call,
-    executed,
-    expressExecuted: express_executed,
-    approved,
   };
 }

--- a/packages/transaction-recovery/src/query-transaction-status/types.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/types.ts
@@ -7,6 +7,7 @@ import type {
   SearchGMPExpressExecuted,
   SearchGMPGasPaid,
   SearchGMPGasStatus,
+  SearchGMPTimespent,
 } from "@axelarjs/api";
 import type { Environment } from "@axelarjs/core";
 
@@ -21,18 +22,22 @@ export type QueryTransactionStatusDependencies = {
 };
 
 export type QueryTransactionStatusResult = {
-  status: GMPTxStatus;
-  error?: QueryTransactionStatusError;
-  timeSpent: number;
-  gasPaidInfo: {
-    status: SearchGMPGasStatus;
-    details: SearchGMPGasPaid;
+  success: boolean;
+  error?: string;
+  data?: {
+    status: GMPTxStatus;
+    error?: QueryTransactionStatusError | undefined;
+    timeSpent: SearchGMPTimespent;
+    gasPaidInfo: {
+      status: SearchGMPGasStatus;
+      details: SearchGMPGasPaid;
+    };
+    callTx: SearchGMPCall;
+    executed?: SearchGMPExecuted | undefined;
+    expressExecuted?: SearchGMPExpressExecuted | undefined;
+    expressExecutedAt?: number | undefined;
+    approved?: SearchGMPApprove | undefined;
   };
-  callTx: SearchGMPCall;
-  executed: SearchGMPExecuted;
-  expressExecuted: SearchGMPExpressExecuted;
-  expressExecutedAt: number;
-  approved: SearchGMPApprove;
 };
 
 export type QueryTransactionStatusError = {

--- a/packages/transaction-recovery/src/query-transaction-status/types.ts
+++ b/packages/transaction-recovery/src/query-transaction-status/types.ts
@@ -1,0 +1,42 @@
+import type {
+  GMPClient,
+  GMPTxStatus,
+  SearchGMPApprove,
+  SearchGMPCall,
+  SearchGMPExecuted,
+  SearchGMPExpressExecuted,
+  SearchGMPGasPaid,
+  SearchGMPGasStatus,
+} from "@axelarjs/api";
+import type { Environment } from "@axelarjs/core";
+
+export type QueryTransactionStatusParams = {
+  txHash: string;
+  txLogIndex?: number;
+  environment: Environment;
+};
+
+export type QueryTransactionStatusDependencies = {
+  gmpClient: GMPClient;
+};
+
+export type QueryTransactionStatusResult = {
+  status: GMPTxStatus;
+  error?: QueryTransactionStatusError;
+  timeSpent: number;
+  gasPaidInfo: {
+    status: SearchGMPGasStatus;
+    details: SearchGMPGasPaid;
+  };
+  callTx: SearchGMPCall;
+  executed: SearchGMPExecuted;
+  expressExecuted: SearchGMPExpressExecuted;
+  expressExecutedAt: number;
+  approved: SearchGMPApprove;
+};
+
+export type QueryTransactionStatusError = {
+  message: string;
+  txHash: string;
+  chain: string;
+};


### PR DESCRIPTION
# Description

[AXE-4225](https://axelarnetwork.atlassian.net/browse/AXE-4225)

Migrated the `queryTransactionStatus` function from SDK v1.

There're some difference between response in v1 and v2 as follows

## Response in V1

**✅ Success:**
```typescript
{
      status: string,
      error: object,
      timeSpent: object,
      gasPaidInfo: object,
      callTx: object,
      executed: object,
      expressExecuted: object,
      approved: object
};
```

**❌ Fail**
```typescript
{
status: "cannot_fetch_status"
}
```

## Response in V2 (This package)

**✅ Success**
```typescript
{
  success: true;
  data: {
    status: GMPTxStatus;
    error?: QueryTransactionStatusError | undefined;
    timeSpent: SearchGMPTimespent;
    gasPaidInfo: {
      status: SearchGMPGasStatus;
      details: SearchGMPGasPaid;
    };
    callTx: SearchGMPCall;
    executed?: SearchGMPExecuted | undefined;
    expressExecuted?: SearchGMPExpressExecuted | undefined;
    expressExecutedAt?: number | undefined;
    approved?: SearchGMPApprove | undefined;
  };
};
```

**❌ Fail**
```typescript
{
  success: false;
  error: "Transaction not found";
};
```

[AXE-4225]: https://axelarnetwork.atlassian.net/browse/AXE-4225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ