### PR TITLE
chore: fix estimateGasFee math rounding issue

### DIFF
--- a/.changeset/forty-birds-cheer.md
+++ b/.changeset/forty-birds-cheer.md
@@ -1,0 +1,5 @@
+---
+"@axelarjs/api": patch
+---
+
+chore: fix rounding issue for estimateGasFee api

--- a/packages/api/src/axelar-query/utils/bigint.spec.ts
+++ b/packages/api/src/axelar-query/utils/bigint.spec.ts
@@ -29,4 +29,12 @@ describe("bigint", () => {
     const result = multiplyFloatByBigInt(floatNum, bigIntNum);
     expect(result).toEqual(1234n);
   });
+
+  it("should handle floating points result", () => {
+    const floatNum = 1.16;
+    const bigIntNum = 169973114000000n;
+
+    const result = multiplyFloatByBigInt(floatNum, bigIntNum);
+    expect(result).toEqual(197168812240000n);
+  });
 });

--- a/packages/api/src/axelar-query/utils/bigint.ts
+++ b/packages/api/src/axelar-query/utils/bigint.ts
@@ -45,7 +45,7 @@ export function multiplyFloatByBigInt(floatNum: number, bigIntNum: bigint) {
   const scalingFactor = 10 ** decimalPlaces;
 
   // Convert float to scaled BigInt (as before)
-  const scaledBigInt = BigInt(floatNum * scalingFactor);
+  const scaledBigInt = BigInt(Math.round(floatNum * scalingFactor));
 
   // Perform the multiplication (both are now BigInts)
   const result = scaledBigInt * bigIntNum;

--- a/packages/api/src/axelar-query/utils/bigint.ts
+++ b/packages/api/src/axelar-query/utils/bigint.ts
@@ -44,8 +44,11 @@ export function multiplyFloatByBigInt(floatNum: number, bigIntNum: bigint) {
   // Scaling factor
   const scalingFactor = 10 ** decimalPlaces;
 
+  // Rounded multiplication of the float by the scaling factor
+  const scaledFloat = Math.round(floatNum * scalingFactor);
+
   // Convert float to scaled BigInt (as before)
-  const scaledBigInt = BigInt(Math.round(floatNum * scalingFactor));
+  const scaledBigInt = BigInt(scaledFloat);
 
   // Perform the multiplication (both are now BigInts)
   const result = scaledBigInt * bigIntNum;


### PR DESCRIPTION
# Description

Fix math rounding issue for `estimateGasFee` api. This issue was detected by running estimateGasFee test script where it tried to fetch gas fee from 3 directions which are: `cosmos -> evm`, `evm -> cosmos`, and `evm -> evm`. The issue seems to be resolved with this fix.