### PR TITLE
fix: search tokens loading times

### DIFF
--- a/.changeset/short-jeans-prove.md
+++ b/.changeset/short-jeans-prove.md
@@ -1,0 +1,5 @@
+---
+"@axelarjs/maestro": patch
+---
+
+Change search erc20 query config so it does not retry on error.

--- a/.changeset/short-jeans-prove.md
+++ b/.changeset/short-jeans-prove.md
@@ -2,4 +2,4 @@
 "@axelarjs/maestro": patch
 ---
 
-Change search erc20 query config so it does not retry on error.
+Change search erc20 query config so it does not retry on error, make RPC calls in getERC20TokenDetails and searchInterchainToken methods concurrent..

--- a/apps/maestro/src/server/routers/erc20/getERC20TokenDetails.ts
+++ b/apps/maestro/src/server/routers/erc20/getERC20TokenDetails.ts
@@ -56,8 +56,8 @@ export const getERC20TokenDetails = publicProcedure
         }
 
         throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `Invalid chainId: ${input.chainId}`,
+          code: "NOT_FOUND",
+          message: `Token not found.`,
         });
       }
 

--- a/apps/maestro/src/server/routers/erc20/getERC20TokenDetails.ts
+++ b/apps/maestro/src/server/routers/erc20/getERC20TokenDetails.ts
@@ -32,32 +32,45 @@ export const getERC20TokenDetails = publicProcedure
       );
 
       if (!chainConfig) {
-        for (const config of chainConfigs) {
+        const promises = chainConfigs.map((config) => {
           const client = ctx.contracts.createERC20Client(
             config,
             input.tokenAddress
           );
 
-          try {
-            const details = await getTokenPublicDetails(
-              client,
+          return getTokenPublicDetails(client, config, input.tokenAddress)
+            .then((details) => ({
+              success: true,
+              details,
               config,
-              input.tokenAddress
-            );
+            }))
+            .catch(() => ({
+              success: false,
+              config,
+              details: null,
+            }));
+        });
 
-            if (details) {
-              return details;
-            }
-          } catch (error) {
-            console.log(
-              `Token ${input.tokenAddress} not found on ${config.name}`
+        const results = await Promise.all(promises);
+
+        const successfulResult = results.find((result) => result.success);
+
+        if (successfulResult) {
+          return successfulResult.details;
+        }
+
+        // Log errors
+        results.forEach((result) => {
+          if (!result.success) {
+            console.error(
+              `Token ${input.tokenAddress} not found on chain: ${result.config.axelarChainName}`
             );
           }
-        }
+        });
 
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: `Token not found.`,
+          message: `Token not found on any chain.`,
         });
       }
 
@@ -76,6 +89,7 @@ export const getERC20TokenDetails = publicProcedure
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
         message: `Failed to get ERC20 token details for ${input.tokenAddress} on ${input.chainId}`,
+        cause: error,
       });
     }
   });

--- a/apps/maestro/src/services/erc20/hooks.ts
+++ b/apps/maestro/src/services/erc20/hooks.ts
@@ -15,6 +15,7 @@ export function useERC20TokenDetailsQuery(input: {
     },
     {
       enabled: isAddress(input.tokenAddress ?? ""),
+      retry: false,
       staleTime: 1000 * 60 * 60 * 24, // 24 hours
       refetchOnWindowFocus: false,
     }


### PR DESCRIPTION
# Description

Fix long loading times when searching for an address.

## ⛑️ **What was done:**

Set `retry: false` for TRPC query to get ERC20 token info. The query was being executed three times and each of these took a long time to complete, with one call being enough to get the same result.

Make the RPC calls to all chains concurrent for a much faster response.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Ready to merge

### 🧪 **How to test:**

Search for tokens, especially tokens that do not exist, and the error should come much earlier than in production.

### 🗒️ **Notes:**

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### ⚖️ **New vs Prod:**

https://github.com/user-attachments/assets/953e9b39-e4d9-4cb9-ad0a-7b93d9f16407

The production app can take up to 35-45x longer to complete the search than the new version.




