### PR TITLE
feat: recover deployment message id when visiting token details page

### DIFF
--- a/.changeset/wild-adults-attack.md
+++ b/.changeset/wild-adults-attack.md
@@ -1,0 +1,5 @@
+---
+"@axelarjs/maestro": patch
+---
+
+create a trcp to recover deployment message ids and use it in token details page to automatically check and recover the missing ids.

--- a/.changeset/wild-adults-attack.md
+++ b/.changeset/wild-adults-attack.md
@@ -2,4 +2,4 @@
 "@axelarjs/maestro": patch
 ---
 
-create a trcp to recover deployment message ids and use it in token details page to automatically check and recover the missing ids.
+create a trpc to recover deployment message ids and use it in token details page to automatically check and recover the missing ids.

--- a/apps/maestro/src/server/routers/interchainToken/index.ts
+++ b/apps/maestro/src/server/routers/interchainToken/index.ts
@@ -12,6 +12,7 @@ import { getTokenManagerABI } from "./getTokenManagerABI";
 import { recordInterchainTokenDeployment } from "./recordInterchainTokenDeployment";
 import { recordRemoteTokensDeployment } from "./recordRemoteTokensDeployment";
 import { recoverCanonicalTokenByTokenId } from "./recoverCanonicalTokenByTokenId";
+import { recoverDeploymentMessageIdByTokenId } from "./recoverDeploymentMessageIdByTokenId";
 import { searchInterchainToken } from "./searchInterchainToken";
 import { setInterchainTokenIconUrl } from "./setInterchainTokenIconUrl";
 
@@ -30,6 +31,7 @@ export const interchainTokenRouter = router({
   recordRemoteTokensDeployment,
   findInterchainTokenByTokenId,
   recoverCanonicalTokenByTokenId,
+  recoverDeploymentMessageIdByTokenId,
   setInterchainTokenIconUrl,
 });
 

--- a/apps/maestro/src/server/routers/interchainToken/recoverDeploymentMessageIdByTokenId.ts
+++ b/apps/maestro/src/server/routers/interchainToken/recoverDeploymentMessageIdByTokenId.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+import { hex64Literal } from "~/lib/utils/validation";
+import { protectedProcedure } from "~/server/trpc";
+
+export const recoverDeploymentMessageIdByTokenId = protectedProcedure
+  .input(
+    z.object({
+      tokenId: hex64Literal(),
+    })
+  )
+  .mutation(async ({ ctx, input }) => {
+    // constraint: token must be in db
+    const { postgres } = ctx.persistence;
+
+    const token = await postgres.getInterchainTokenByTokenId(input.tokenId);
+
+    if (!token) {
+      throw new Error("Token not found");
+    }
+
+    // is missing deploymentMessageId?
+    if (!token.deploymentMessageId) {
+      // try to find deployment tx hash from indexed events limiting by the token deployment timestamp
+
+      const fromTime = (token.createdAt as Date).getTime() / 1000;
+      const bufferLenth = 60 * 60 * 8; // 8 hours
+      const toTime = fromTime + bufferLenth;
+
+      const deployments = await ctx.services.gmp.searchGMP({
+        contractMethod: ["InterchainTokenDeploymentStarted"],
+        _source: {
+          excludes: [
+            "refunded",
+            "refund_nonce",
+            "receipt",
+            "gas",
+            "approved",
+            "gas_price_rate",
+            "fees",
+            "gas_paid",
+            "to_refund",
+            "confirm",
+            "command_id",
+            "time_spent",
+            "executed.receipt",
+            "executed.transaction",
+          ],
+          includes: [
+            "status",
+            "call.transactionHash",
+            "call.returnValues.destinationChain",
+            "interchain_token_deployment_started.tokenId",
+          ],
+        },
+        fromTime: fromTime,
+        toTime: toTime,
+        size: 1000,
+      });
+
+      const validEntries = deployments.filter(
+        (x) =>
+          x.interchain_token_deployment_started &&
+          x.interchain_token_deployment_started.tokenId === input.tokenId
+      );
+
+      const results = validEntries.map((x) => {
+        const logIndex = x.call.logIndex ?? x.call._logIndex ?? 0;
+        return {
+          status: x.status,
+          destinationChain: x.call.returnValues.destinationChain,
+          txHash: x.call.transactionHash,
+          logIndex,
+          deploymentMessageId: `${x.call.transactionHash}-${logIndex}`,
+        };
+      });
+
+      if (results.length) {
+        await postgres.updateInterchainTokenDeploymentMessageId(
+          input.tokenId,
+          `${results[0].txHash}-0`
+        );
+
+        for (const result of results) {
+          await postgres.updateRemoteInterchainTokenDeploymentMessageId(
+            input.tokenId,
+            result.destinationChain,
+            result.deploymentMessageId
+          );
+        }
+
+        return "updated";
+      }
+    }
+  });

--- a/apps/maestro/src/server/routers/interchainToken/recoverDeploymentMessageIdByTokenId.ts
+++ b/apps/maestro/src/server/routers/interchainToken/recoverDeploymentMessageIdByTokenId.ts
@@ -24,8 +24,8 @@ export const recoverDeploymentMessageIdByTokenId = protectedProcedure
       // try to find deployment tx hash from indexed events limiting by the token deployment timestamp
 
       const fromTime = (token.createdAt as Date).getTime() / 1000;
-      const bufferLenth = 60 * 60 * 8; // 8 hours
-      const toTime = fromTime + bufferLenth;
+      const bufferLength = 60 * 60 * 8; // 8 hours
+      const toTime = fromTime + bufferLength;
 
       const deployments = await ctx.services.gmp.searchGMP({
         contractMethod: ["InterchainTokenDeploymentStarted"],
@@ -78,7 +78,7 @@ export const recoverDeploymentMessageIdByTokenId = protectedProcedure
       if (results.length) {
         await postgres.updateInterchainTokenDeploymentMessageId(
           input.tokenId,
-          `${results[0].txHash}-0`
+          results[0].deploymentMessageId
         );
 
         for (const result of results) {

--- a/apps/maestro/src/services/db/postgres/MaestroPostgresClient.ts
+++ b/apps/maestro/src/services/db/postgres/MaestroPostgresClient.ts
@@ -196,6 +196,32 @@ export default class MaestroPostgresClient {
     return await query;
   }
 
+  async updateInterchainTokenDeploymentMessageId(
+    tokenId: string,
+    deploymentMessageId: string
+  ) {
+    await this.db
+      .update(interchainTokens)
+      .set({ deploymentMessageId, updatedAt: new Date() })
+      .where(eq(interchainTokens.tokenId, tokenId));
+  }
+
+  async updateRemoteInterchainTokenDeploymentMessageId(
+    tokenId: string,
+    axealrChainId: string,
+    deploymentMessageId: string
+  ) {
+    await this.db
+      .update(remoteInterchainTokens)
+      .set({ deploymentMessageId, updatedAt: new Date() })
+      .where(
+        and(
+          eq(remoteInterchainTokens.tokenId, tokenId),
+          eq(remoteInterchainTokens.axelarChainId, axealrChainId)
+        )
+      );
+  }
+
   /**
    * Returns the interchain token with the given `chainId` and `tokenAddress`,
    * including its remote interchain tokens.


### PR DESCRIPTION
# Description

Recover the deployment message id when visiting the token details page if missing.

## ⛑️ **What was done:**

- Create query to recover message id by token id. 
- Check if the id is missing in every visit to token details page and try to recover it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Ready to merge

### 🧪 **How to test:**

Go to the details page of a token with a missing deployment message it, check it shows as unregistered ITS token and wait for it to update.
You can achieve this by deleting the message id from the db for an existing token.

### 🗒️ **Notes:**

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### 🖼️ **Recording:**

https://github.com/user-attachments/assets/25b9ca33-fe5d-4d00-96ab-a21cfb2f6225



Check how the token with the missing deployment message id updates automatically in the details page after some seconds.


