### PR TITLE
fix: search interchain tokens query searching only first chain

### DIFF
--- a/.changeset/orange-dodos-sparkle.md
+++ b/.changeset/orange-dodos-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@axelarjs/maestro": patch
+---
+
+fix search interchain tokens query issue where it was only looking at the results for the first chain searched

--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -300,7 +300,9 @@ async function scanChains(
       });
   });
   const results = await Promise.all(promises);
-  const validResult = results.find((result) => !!result);
+  const validResult = results.find(
+    (result) => result !== null && result !== undefined
+  );
 
   return validResult || null;
 }

--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -300,9 +300,7 @@ async function scanChains(
       });
   });
   const results = await Promise.all(promises);
-  const validResult = results.find(
-    (result) => result !== null && result !== undefined
-  );
+  const validResult = results.find((result) => result);
 
   return validResult || null;
 }

--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -299,9 +299,8 @@ async function scanChains(
         return null;
       });
   });
-
   const results = await Promise.all(promises);
-  const validResult = results.find((result) => result !== null);
+  const validResult = results.find((result) => !!result);
 
   return validResult || null;
 }


### PR DESCRIPTION
# Description

## 🎫 **Issue:**

- [ITS-453](https://github.com/axelarnetwork/axelarjs/issues/453)

## ⛑️ **What was done:**

Fixed an issue where searching a token without specifying chain id was failing.
The issue was that the query was returning `undefined` and not `null` as expected by the code, returning only the result of the first chain searched.
When the chain was specified, the query was looking for the specified chain first, that's what made it work.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Ready to merge

### 🧪 **How to test:**

Run the app and go to `http://localhost:3000/api/interchain-token/search?tokenAddress=0x0c66d591d1ff5944A44aebB65c33f6B6e82a124F`
The same query without the change should fail.

### 🗒️ **Notes:**

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### 🎥 **Recording:**

https://github.com/user-attachments/assets/c6a91790-ffee-4523-85a8-714581aa27a3

Closes #453

