### PR TITLE
fix: cannot find remote interchain token

### DIFF
--- a/apps/maestro/src/services/interchainToken/hooks.ts
+++ b/apps/maestro/src/services/interchainToken/hooks.ts
@@ -6,7 +6,7 @@ import { trpc } from "~/lib/trpc";
 
 export function useInterchainTokenDetailsQuery(input: {
   chainId?: number;
-  tokenAddress?: `0x${string}`;
+  tokenAddress?: `0x${string}` | null;
 }) {
   return trpc.interchainToken.getInterchainTokenDetails.useQuery(
     {

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/index.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/index.tsx
@@ -31,8 +31,8 @@ const InterchainTokensPage: FC = () => {
   });
 
   const { data: interchainTokenDetails } = useInterchainTokenDetailsQuery({
-    chainId: routeChain?.id,
-    tokenAddress,
+    chainId: interchainToken?.chainId,
+    tokenAddress: interchainToken?.tokenAddress,
   });
 
   const { data: tokenDetails } = useERC20TokenDetailsQuery({


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-5295

This PR fixes the token details page doesn't render correctly when user searched with the remote interchain token address.