### PR TITLE
feat: support devnet amplifier

### DIFF
--- a/apps/maestro/package.json
+++ b/apps/maestro/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@axelar-network/axelar-cgp-sui": "0.0.0-snapshot.424bc13",
-    "@axelar-network/axelarjs-sdk": "0.17.0",
+    "@axelar-network/axelarjs-sdk": "0.17.1-alpha.5",
     "@axelarjs/api": "workspace:*",
     "@axelarjs/core": "workspace:*",
     "@axelarjs/evm": "workspace:*",

--- a/apps/maestro/src/config/env.ts
+++ b/apps/maestro/src/config/env.ts
@@ -15,7 +15,7 @@ export const NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID = Maybe.of(
 
 export const NEXT_PUBLIC_NETWORK_ENV = String(
   process.env.NEXT_PUBLIC_NETWORK_ENV ?? "testnet"
-) as "mainnet" | "testnet";
+) as "mainnet" | "testnet" | "devnet-amplifier";
 
 export const NEXT_PUBLIC_AXELAR_CONFIGS_URL = Maybe.of(
   process.env.NEXT_PUBLIC_AXELAR_CONFIGS_URL

--- a/apps/maestro/src/config/evm-chains.ts
+++ b/apps/maestro/src/config/evm-chains.ts
@@ -395,7 +395,7 @@ export const ALL_CHAINS: ExtendedWagmiChainConfig[] = [
     environment: ENVIRONMENTS.testnet,
   },
   {
-    ...avalanche,
+    ...avalancheFuji,
     axelarChainId: "avalanche-fuji",
     axelarChainName: "avalanche-fuji",
     environment: ENVIRONMENTS.devnet,

--- a/apps/maestro/src/config/evm-chains.ts
+++ b/apps/maestro/src/config/evm-chains.ts
@@ -49,11 +49,12 @@ import { NEXT_PUBLIC_NETWORK_ENV } from "./env";
 export interface ExtendedWagmiChainConfig extends Chain {
   axelarChainId: string;
   axelarChainName: string;
-  environment: "mainnet" | "testnet";
+  environment: "mainnet" | "testnet" | "devnet-amplifier";
 }
 
 const ENVIRONMENTS = {
   mainnet: "mainnet",
+  devnet: "devnet-amplifier",
   testnet: "testnet",
 } as const;
 
@@ -100,7 +101,7 @@ export const ALL_CHAINS: ExtendedWagmiChainConfig[] = [
     id: 103,
     axelarChainId: "sui",
     axelarChainName: "sui",
-    environment: ENVIRONMENTS.testnet,
+    environment: ENVIRONMENTS.devnet,
     name: "Sui Testnet",
     nativeCurrency: {
       name: "SUI",
@@ -392,6 +393,24 @@ export const ALL_CHAINS: ExtendedWagmiChainConfig[] = [
     axelarChainId: "blast-sepolia",
     axelarChainName: "blast-sepolia",
     environment: ENVIRONMENTS.testnet,
+  },
+  {
+    ...avalanche,
+    axelarChainId: "avalanche-fuji",
+    axelarChainName: "avalanche-fuji",
+    environment: ENVIRONMENTS.devnet,
+  },
+  {
+    ...optimismSepolia,
+    axelarChainId: "optimism-sepolia",
+    axelarChainName: "optimism-sepolia",
+    environment: ENVIRONMENTS.devnet,
+  },
+  {
+    ...sepolia,
+    axelarChainId: "eth-sepolia",
+    axelarChainName: "eth-sepolia",
+    environment: ENVIRONMENTS.devnet,
   },
 ] as const;
 

--- a/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
+++ b/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
@@ -354,9 +354,6 @@ export function useDeployAndRegisterRemoteInterchainTokenMutation(
     }
 
     const registerTxData = destinationChainNames.map((destinationChain, i) => {
-      if (destinationChain === "sui") {
-        destinationChain = "sui-test2";
-      }
       const registerData =
         INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainToken.data({
           ...commonArgs,

--- a/apps/maestro/src/features/suiHooks/useDeployToken.ts
+++ b/apps/maestro/src/features/suiHooks/useDeployToken.ts
@@ -14,6 +14,14 @@ const findCoinDataObject = (registerTokenResult: any) => {
   ).objectId;
 };
 
+export type DeployTokenParams = {
+  symbol: string;
+  name: string;
+  decimals: number;
+  destinationChainIds: string[];
+  skipRegister?: boolean;
+};
+
 type SuiObjectCreated =
   | Extract<SuiObjectChange, { type: "created" }>
   | undefined;
@@ -45,18 +53,14 @@ export default function useTokenDeploy() {
         return result;
       },
     });
+
   const { mutateAsync: getDeployTokenTxBytes } =
     trpc.sui.getDeployTokenTxBytes.useMutation({
       onError(error) {
         console.log("error in usedeploytoken", error.message);
       },
     });
-  // const { mutateAsync: getRegisterTokenTx } =
-  //   trpc.sui.getRegisterTokenTx.useMutation({
-  //     onError(error) {
-  //       console.log("error in getRegisterTokenTx", error.message);
-  //     },
-  //   });
+
   const { mutateAsync: getRegisterAndSendTokenDeploymentTxBytes } =
     trpc.sui.getRegisterAndDeployTokenTx.useMutation({
       onError(error) {
@@ -68,13 +72,10 @@ export default function useTokenDeploy() {
     symbol,
     name,
     decimals,
+    destinationChainIds,
     skipRegister = false,
-  }: {
-    symbol: string;
-    name: string;
-    decimals: number;
-    skipRegister?: boolean;
-  }) => {
+  }: DeployTokenParams) => {
+    console.log("deployToken", symbol, name, decimals, destinationChainIds);
     if (!currentAccount) {
       throw new Error("Wallet not connected");
     }
@@ -125,6 +126,7 @@ export default function useTokenDeploy() {
         symbol,
         tokenPackageId: tokenAddress,
         metadataId: metadata.objectId,
+        destinationChains: destinationChainIds,
       });
       const sendTokenTx = Transaction.from(sendTokenTxJSON as string);
       const sendTokenResult = await signAndExecuteTransaction({

--- a/apps/maestro/src/pages/_app.tsx
+++ b/apps/maestro/src/pages/_app.tsx
@@ -28,7 +28,7 @@ import NProgressBar from "~/ui/layouts/NProgressBar";
 
 import "@tanstack/react-query";
 
-type NetworkEnv = "mainnet" | "testnet" | "devnet" | "localnet";
+// type NetworkEnv = "mainnet" | "testnet" | "devnet" | "localnet";
 
 const networks = {
   localnet: { url: getFullnodeUrl("localnet") },
@@ -103,7 +103,11 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
             <WagmiConfigPropvider>
               <SuiClientProvider
                 networks={networks}
-                network={process.env.NEXT_PUBLIC_NETWORK_ENV as NetworkEnv}
+                network={
+                  process.env.NEXT_PUBLIC_NETWORK_ENV === "mainnet"
+                    ? "mainnet"
+                    : "testnet"
+                }
               >
                 <WalletProvider autoConnect>
                   {!isSSR && (

--- a/apps/maestro/src/server/context.ts
+++ b/apps/maestro/src/server/context.ts
@@ -49,9 +49,11 @@ const createContextInner = async ({ req, res }: ContextConfig) => {
     apiKey: process.env.OPENAI_API_KEY,
   });
 
-  const axelarQueryClient = createAxelarQueryClient(NEXT_PUBLIC_NETWORK_ENV);
+  const networkEnv =
+    NEXT_PUBLIC_NETWORK_ENV === "mainnet" ? "mainnet" : "testnet";
 
-  const axelarConfigClient = createAxelarConfigClient(NEXT_PUBLIC_NETWORK_ENV);
+  const axelarQueryClient = createAxelarQueryClient(networkEnv);
+  const axelarConfigClient = createAxelarConfigClient(networkEnv);
 
   return {
     req,

--- a/apps/maestro/src/server/routers/sui/config/devnet-amplifier.json
+++ b/apps/maestro/src/server/routers/sui/config/devnet-amplifier.json
@@ -1,86 +1,74 @@
 {
-  "sui-test2": {
-      "name": "sui-test2",
-      "axelarId": "sui-test2",
-      "id": "sui-test2",
-      "networkType": "testnet",
-      "tokenSymbol": "SUI",
-      "rpc": "https://fullnode.testnet.sui.io:443",
-      "contracts": {
-        "Utils": {
-          "address": "0xac843343c6f70ff29e782f5dd11aea5ba4874ce4f29bad6ce4a25f7837e8e950"
+  "sui": {
+    "name": "Sui",
+    "axelarId": "sui",
+    "networkType": "testnet",
+    "rpc": "https://sui-testnet-rpc.publicnode.com:443",
+    "tokenSymbol": "SUI",
+    "explorer": {
+      "name": "Suiscan",
+      "url": "https://suiscan.xyz/testnet"
+    },
+    "contracts": {
+      "AxelarGateway": {
+        "address": "0x936c1f0714a06fac58edc57bb95276bb0ad1e6ae930e5c232fdfec4a18f65818",
+        "objects": {
+          "Gateway": "0xf9eee074e8de1c3b4e12e0d3cdda33b7c41f0047756eaafc68224b1303e81a9b",
+          "UpgradeCap": "0x7137b2f35ef71bac778fe6be0c0a641f30659289473abe28c2fac2374f77f060",
+          "Gatewayv0": "0xa042055976ebcf01930c33f304a83bc0795c0f5c7b6c4056d2ca35a42dd8909a"
         },
-        "VersionControl": {
-          "address": "0x812fdebd483384b56abddd57159707865687f742d0dc91d0057431f71c5f796f"
+        "domainSeparator": "0x8a4b7c0ae3e02feb8a34711648ee44a4c9fc56ac90b41b74619a75e75de13c37",
+        "operator": "0x1471a8acf730a05a7d720e52c7ef94024c7351502c83b80da5583db2f6b0b8df",
+        "minimumRotationDelay": 0
+      },
+      "Utils": {
+        "address": "0xd937e31b88f0c35c65210e5a38b8222044bf0624227a220c0ee5ec48f86aa8e0"
+      },
+      "VersionControl": {
+        "address": "0x1faa10c04e3ccdd0c5f1dbe43a63704be46f00903032d44b4eb4b87c16a18276"
+      },
+      "RelayerDiscovery": {
+        "address": "0x4075fefb4216afcdeef604aa9880830720316156025c9addcb6b04a3f4a4c00c",
+        "objects": {
+          "RelayerDiscovery": "0x0fdaeba8d37107f0b637a363f4779683cd2b6232966acc197ccb88e212886d3b",
+          "RelayerDiscoveryv0": "0x952a1cb19ad86c75466b10375a81d9773a52b74b4cf97fff8ee2380ba4b490a0"
+        }
+      },
+      "GasService": {
+        "address": "0xef105cb526865ac558c3ee5e0ef6b63cffb730b4a784bca8ff40dcba66576ca8",
+        "objects": {
+          "GasCollectorCap": "0xa2e9b881c62decb65bd8b783f1e8ef9523babbd7914142b33f7889e7c201fa96",
+          "GasService": "0xc4b2024a3a51c0f9f15a617efd81ddfab8c36c0b707027e6707cfc9cf0741d29",
+          "GasServicev0": "0x37b4b94650db69763d7449f48eb68bc5e8e335a5b7c89d308d0ddc1ab6024033"
+        }
+      },
+      "Abi": {
+        "address": "0xeac9d24da6b5be005ca01577b0fb4dd756e44d45ad105c33a914e0e2b3b03138"
+      },
+      "ITS": {
+        "address": "0x6c3d772d81c8ef130de111de4c8c4172856b6056aa3949ff26d89fe3035b64bd",
+        "objects": {
+          "ITS": "0x83be4eb9b623ec0d9433cca2cebf30a9fde5935d9cd579f19a3e08b89603cfe7",
+          "ITSv0": "0x0d89aca2ad447b16f7f35ec8c47561dc00126f1f6699c851b49f44b432d8e00e",
+          "ChannelId": "0x13bc8c2b3fda3a0a3ca30c4d518f47eff9d523c73b792a2fcf3064ae9f3902bc",
+          "OwnerCap": "0x2dd1c932d894d5416d373474b58fe7f0d0bae2932220784657f3f7b2f95de4b3"
         },
-        "AxelarGateway": {
-          "address": "0x3c28103ff11b67c4f07761ad87423b5afb470ab391b8fa735b16755a091aacfd",
-          "objects": {
-            "Gateway": "0x32100a9af641060281f61d95c9a93d4e0437dfe7dda34618d154e6fe321d55b5",
-            "UpgradeCap": "0xb73bfb2bf011a10169060c6ab11599e5fa4e10d217c0d8312538ad4accb22780",
-            "Gatewayv0": "0x5d53894cfd16c3b36d4412226b4a82abec29f29e71b9a9f98a031cddfae8dbf0"
-          },
-          "domainSeparator": "0x05b8831cd87c82fadd1e4967a45eb3401dfc6bf5f74b827d8f525992c09403ef",
-          "operator": "0x1471a8acf730a05a7d720e52c7ef94024c7351502c83b80da5583db2f6b0b8df",
-          "minimumRotationDelay": 0
-        },
-        "RelayerDiscovery": {
-          "address": "0x7d51c9e5ae0616fb6c37d58449d06376f0ab0dc7f340406bdbe0c49f211013d1",
-          "objects": {
-            "RelayerDiscovery": "0xb4016df3ed41c9d18788f5c5fdaf03c1a88b3e6369d47c9ad81be268381e094f",
-            "RelayerDiscoveryv0": "0x85262593b3154097b1f538f2f9e7da19627d2fb183880e8e4bdba7de86bdfe8a"
-          }
-        },
-        "GasService": {
-          "address": "0x6ae06190270188566e36f7744c1c441bb44279b7f121f666d4ca281ed521b444",
-          "objects": {
-            "GasCollectorCap": "0x4ff137ea8a58e83b2e62ad143f541660412360d5b73b1f1bc4d673560e2b1244",
-            "GasService": "0x9e22d1435e1d22abb178440f9cc8d3be27fbf95960b5ad787057a0b1a4dce1a4",
-            "GasServicev0": "0xecbf2103ad3a7ac48ac8de12ca3de513b1dfd795bf5f6bbdc31b0513a57c6c4a"
-          }
-        },
-        "Abi": {
-          "address": "0xb25d256e529286388228af86c5c56640f9ececc8ed102bc85b447ec821b5265c"
-        },
-        "ITS": {
-          "address": "0x76fb49dcce532b8659e06ee6472adcf62a29e0f06d48b99a0bbed0ecba11e54d",
-          "objects": {
-            "ITS": "0x881c59ce68fae134cf38bd4a339951798f9d385c55eef6f5d571952d73eb6a26",
-            "ITSv0": "0xedb957a8290ed450d5b77a8df9b4bb47e80f485ed5bc5919c3b25495eada7cab",
-            "ChannelId": "0xc848bdd1dc546487c43f3d60ec089945644e17ffb52b0a667884dc884d6666a1",
-            "OwnerCap": "0x881d33f52cc1c3dcc28af7f040a14cd5c5386f8214171f758b7e87521c3c7c3a"
-          },
-          "trustedAddresses": {
-            "eth-sepolia": [
-              "hub"
-            ],
-            "optimism-sepolia": [
-              "hub"
-            ],
-            "avalanche-fuji": [
-              "hub"
-            ],
-            "axelarnet": [
-              "axelar10jzzmv5m7da7dn2xsfac0yqe7zamy34uedx3e28laq0p6f3f8dzqp649fp"
-            ]
-          }
-        },
-        "Example": {
-          "address": "0x36b38c261f0aeed4ab06c5312323c6a8b6883018f157ffb75906f09729b181aa",
-          "objects": {
-            "GmpSingleton": "0xa555eb707da9e280f0b38cb0d7e0e75bfb576fae363d0a7a2fe341f68940e277",
-            "GmpChannelId": "0xbdab4917a6062e6b74023bbb2cfc27fc0a10661ef5b8b7d72950c24bb7e54c16",
-            "ItsSingleton": "0xbdd269f6eefe806b6929d0f9708fd1d0994db1ca2a77303f81dc130d2068a7b8",
-            "ItsChannelId": "0xddb468cbb25bfd292a6cc878fe8bf72fa320c17cd99bd5375d8f20a31e2649a3"
-          }
-        },
-        "Operators": {
-          "address": "0x0b92f476bdb857de002e70eba31ebaa342c4d7d8550d7ab0e0219fe9501e19f8",
-          "objects": {
-            "Operators": "0xbf8fff27484701828c18b9d30ed249a77fe703535f978d1eeddb288dc5e7ae1f",
-            "OwnerCap": "0x2e9dc6979c7e41a7e13561628b3bc53cf237837ddf1e1f67984c59782e3f8cf3"
-          }
+        "trustedAddresses": {
+          "axelar": [
+            "axelar10jzzmv5m7da7dn2xsfac0yqe7zamy34uedx3e28laq0p6f3f8dzqp649fp",
+            "axelar157hl7gpuknjmhtac2qnphuazv2yerfagva7lsu9vuj2pgn32z22qa26dk4"
+          ]
+        }
+      },
+      "Example": {
+        "address": "0xdafe98f7add273eba84ef4d052535da2e264459845b19a9a1aa7d0801e75e177",
+        "objects": {
+          "GmpSingleton": "0x333bb32e97745c4cb93761834d6b7c18142b96f5d77985a0cfaf90f966d41d14",
+          "GmpChannelId": "0xb21972e89645ac75909afff39d18e32e3691951f1b1b1645e526bc6b902efc87",
+          "ItsSingleton": "0xf6c5a78b45dbf65d7c57b41fcdf47b04967c88c2844a1f7b4a366f4be0fa7860",
+          "ItsChannelId": "0x8bd7f12ccc0e1b97cf0cfaf4c1630200541acdad6e7eeabf0ec9c43290f494d0"
         }
       }
     }
   }
+}

--- a/apps/maestro/src/server/routers/sui/index.ts
+++ b/apps/maestro/src/server/routers/sui/index.ts
@@ -8,7 +8,7 @@ import { buildTx } from "./utils/utils";
 
 // Initialize SuiClient directly with RPC from config
 const suiClient = new SuiClient({
-  url: config["sui-test2"].rpc,
+  url: config["sui"].rpc,
 });
 
 const suiServiceBaseUrl = "https://melted-fayth-nptytn-57e5d396.koyeb.app";
@@ -99,13 +99,13 @@ export const suiRouter = router({
 
         const itsObjectId = ITS.objects.ITS;
 
-        const trustedDestinationChains = Object.keys(ITS.trustedAddresses);
-        for (const destinationChain of destinationChains) {
-          if (!trustedDestinationChains.includes(destinationChain)) {
-            console.log(`destination chain ${destinationChain} not trusted`);
-            return undefined;
-          }
-        }
+        // const trustedDestinationChains = Object.keys(ITS.trustedAddresses);
+        // for (const destinationChain of destinationChains) {
+        //   if (!trustedDestinationChains.includes(destinationChain)) {
+        //     console.log(`destination chain ${destinationChain} not trusted`);
+        //     return undefined;
+        //   }
+        // }
 
         const coinMetadata = await suiClient.getCoinMetadata({
           coinType: tokenType,
@@ -125,11 +125,9 @@ export const suiRouter = router({
           const [TokenId] = await txBuilder.moveCall({
             target: `${ITS.address}::token_id::from_info`,
             typeArguments: [tokenType],
-            // TODO: once the sui contract is updated, remove the duplicated decimals
             arguments: [
               coinMetadata.name,
               coinMetadata.symbol,
-              txBuilder.tx.pure.u8(coinMetadata.decimals),
               txBuilder.tx.pure.u8(coinMetadata.decimals),
               txBuilder.tx.pure.bool(false),
               txBuilder.tx.pure.bool(false),

--- a/apps/maestro/src/server/routers/sui/index.ts
+++ b/apps/maestro/src/server/routers/sui/index.ts
@@ -74,8 +74,7 @@ export const suiRouter = router({
         const response = await fetch(
           `${suiServiceBaseUrl}/chain/devnet-amplifier`
         );
-        const _chainConfig = await response.json();
-        const chainConfig = _chainConfig.chains["sui-test2"];
+        const chainConfig = await response.json();
         const { sender, symbol, tokenPackageId, metadataId } = input;
 
         const tokenType = `${tokenPackageId}::${symbol.toLowerCase()}::${symbol.toUpperCase()}`;

--- a/apps/maestro/src/server/utils.ts
+++ b/apps/maestro/src/server/utils.ts
@@ -91,7 +91,7 @@ export async function axelarConfigs<TCacheKey extends string>(
   }
 
   const chainConfigs = await axelarConfigClient.getAxelarConfigs(
-    NEXT_PUBLIC_NETWORK_ENV
+    NEXT_PUBLIC_NETWORK_ENV === "mainnet" ? "mainnet" : "testnet"
   );
 
   // cache for 1 hour

--- a/apps/maestro/src/server/utils.ts
+++ b/apps/maestro/src/server/utils.ts
@@ -56,6 +56,11 @@ export async function evmChains<TCacheKey extends string>(
         wagmi: wagmiConfig,
       };
 
+      // TODO: remove this once we have ITS hub on testnet
+      if (NEXT_PUBLIC_NETWORK_ENV === "devnet-amplifier") {
+        entry.info.id = wagmiConfig.axelarChainId;
+      }
+
       return {
         ...acc,
         [chain.id]: entry,

--- a/apps/maestro/src/services/axelarjsSDK/index.ts
+++ b/apps/maestro/src/services/axelarjsSDK/index.ts
@@ -20,8 +20,8 @@ async function estimateGasFee(params: EstimateGasFeeInput): Promise<bigint> {
   console.log("params estimateGasFee", params);
   // TODO: remove when sdk support for sui is ready
   if (
-    params.destinationChainId.includes("sui") ||
-    params.sourceChainId.includes("sui")
+    params.sourceChainId.includes("sui") ||
+    params.destinationChainId.includes("sui")
   ) {
     response = "20000000000000000";
   } else
@@ -85,6 +85,8 @@ async function getChainInfo(params: GetChainInfoInput) {
   const chains = await getChainConfigs({
     environment: process.env.NEXT_PUBLIC_NETWORK_ENV as Environment,
   });
+
+  console.log("chains", chains);
 
   const chainConfig = chains.find((chain) => chain.id === params.axelarChainId);
 

--- a/apps/maestro/src/services/axelarscan/index.ts
+++ b/apps/maestro/src/services/axelarscan/index.ts
@@ -2,4 +2,6 @@ import { createAxelarscanClient } from "@axelarjs/api/axelarscan";
 
 import { NEXT_PUBLIC_NETWORK_ENV } from "~/config/env";
 
-export default createAxelarscanClient(NEXT_PUBLIC_NETWORK_ENV);
+export default createAxelarscanClient(
+  NEXT_PUBLIC_NETWORK_ENV === "mainnet" ? "mainnet" : "testnet"
+);


### PR DESCRIPTION
This PR supports `devnet-amplifier` env. 

To run the web server, the `NEXT_PUBLIC_NETWORK_ENV="devnet-amplifier"` env needs to be set. 

It also supports multiple token deployments from sui to evm chains in this pr as well.