### PR TITLE
fix: undefined chain after token transfer from flow

### DIFF
--- a/apps/maestro/src/server/routers/gmp/getTransactionStatusOnDestinationChains.ts
+++ b/apps/maestro/src/server/routers/gmp/getTransactionStatusOnDestinationChains.ts
@@ -15,6 +15,7 @@ export const SEARCHGMP_SOURCE = {
     "executed",
     "callback",
     "interchain_token_deployment_started.destinationChain",
+    "interchain_transfer.destinationChain",
   ],
   excludes: [
     "call.transaction",
@@ -61,6 +62,7 @@ export const getTransactionStatusOnDestinationChains = publicProcedure
               call,
               status: firstHopStatus,
               interchain_token_deployment_started: tokenDeployment,
+              interchain_transfer: tokenTransfer,
             } = gmpData;
 
             const chainType = gmpData.call.chain_type;
@@ -77,6 +79,7 @@ export const getTransactionStatusOnDestinationChains = publicProcedure
             }
 
             const destinationChain =
+              tokenTransfer?.destinationChain?.toLowerCase() ||
               tokenDeployment?.destinationChain?.toLowerCase() ||
               call.returnValues.destinationChain.toLowerCase();
 


### PR DESCRIPTION
# Description

Fixes an issue where the destination chain becomes undefined after initiating a token transfer transaction from Flow.

## Issue
- The backend incorrectly uses 'axelar' as the destination chain ID
- Token transfers from Flow are 2-hop transactions (Flow → Axelar → Final Destination)
- Using 'axelar' as the destination chain ID is invalid since it's only an intermediary

## Solution
- Read the correct destination chain ID from the `InterchainTransfer` event
- Utilize the existing searchGMP response to retrieve this information, which we already use for transaction status monitoring