### PR TITLE
fix: token deployment and token transfer in token details

### DIFF
--- a/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
+++ b/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { zeroAddress, type TransactionReceipt } from "viem";
 import { useWaitForTransactionReceipt } from "wagmi";
 
-import { NEXT_PUBLIC_NETWORK_ENV } from "~/config/env";
 import useDeployToken from "~/features/suiHooks/useDeployToken";
 import {
   useReadInterchainTokenFactoryInterchainTokenId,
@@ -20,7 +19,7 @@ import {
   decodeDeploymentMessageId,
   type DeploymentMessageId,
 } from "~/lib/drizzle/schema";
-import { useAccount, useChainId } from "~/lib/hooks";
+import { SUI_CHAIN_ID, useAccount, useChainId } from "~/lib/hooks";
 import { trpc } from "~/lib/trpc";
 import { isValidEVMAddress } from "~/lib/utils/validation";
 import type { EstimateGasFeeMultipleChainsOutput } from "~/server/routers/axelarjsSDK";
@@ -260,8 +259,6 @@ export function useDeployAndRegisterRemoteInterchainTokenMutation(
   }, [deployerAddress, input, recordDeploymentAsync, tokenAddress, tokenId]);
 
   const writeAsync = useCallback(async () => {
-    const SUI_CHAIN_ID = NEXT_PUBLIC_NETWORK_ENV === "mainnet" ? 101 : 103;
-
     await recordDeploymentDraft();
     if (chainId === SUI_CHAIN_ID && input) {
       const result = await deployToken({

--- a/apps/maestro/src/features/ManageInterchainToken/actions/transfer-operatorship/TransferInterchainTokenOperatorship.tsx
+++ b/apps/maestro/src/features/ManageInterchainToken/actions/transfer-operatorship/TransferInterchainTokenOperatorship.tsx
@@ -10,6 +10,7 @@ import { toast } from "@axelarjs/ui/toaster";
 import { useCallback, useEffect, useMemo, type FC } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 
+import { isValidSuiAddress } from "@mysten/sui/utils";
 import {
   isAddress,
   TransactionExecutionError,
@@ -126,7 +127,7 @@ export const TransferInterchainTokenOperatorship: FC = () => {
       try {
         if (chainId === SUI_CHAIN_ID) {
           const result = await transferTreasuryCap(
-            state.tokenId,
+            tokenDetails?.tokenAddress as string,
             data.recipientAddress
           );
 
@@ -178,10 +179,10 @@ export const TransferInterchainTokenOperatorship: FC = () => {
       setTxState,
       chainId,
       transferTreasuryCap,
-      state.tokenId,
+      tokenDetails?.tokenAddress,
+      tokenDetails?.tokenManagerAddress,
       onSuccess,
       transferOperatorshipAsync,
-      tokenDetails?.tokenManagerAddress,
     ]
   );
 
@@ -226,8 +227,16 @@ export const TransferInterchainTokenOperatorship: FC = () => {
               {...register("recipientAddress", {
                 disabled: isTransfering,
                 validate(value) {
-                  if (!value || !isAddress(value)) {
-                    return "Invalid address";
+                  if (!value) return "Address is required";
+
+                  if (chainId === SUI_CHAIN_ID) {
+                    if (!isValidSuiAddress(value)) {
+                      return "Invalid Sui address";
+                    }
+                  } else {
+                    if (!isAddress(value)) {
+                      return "Invalid EVM address";
+                    }
                   }
 
                   return true;

--- a/apps/maestro/src/features/ManageInterchainToken/hooks/useTransferTreasuryCapMutation.ts
+++ b/apps/maestro/src/features/ManageInterchainToken/hooks/useTransferTreasuryCapMutation.ts
@@ -12,7 +12,7 @@ export function useTransferTreasuryCapMutation() {
 
   const { mutateAsync: getTransferTreasuryCapTx } =
     trpc.sui.getTransferTreasuryCapTx.useMutation({
-      onError(error) {
+      onError(error: any) {
         console.log("error in getTransferTreasuryCapTx", error.message);
       },
     });
@@ -37,7 +37,10 @@ export function useTransferTreasuryCapMutation() {
   return {
     txState,
     setTxState,
-    transferTreasuryCap: async (tokenId: string, recipientAddress: string) => {
+    transferTreasuryCap: async (
+      tokenAddress: string,
+      recipientAddress: string
+    ) => {
       if (!address) return;
 
       try {
@@ -46,7 +49,7 @@ export function useTransferTreasuryCapMutation() {
         });
 
         const treasuryCapTxJSON = await getTransferTreasuryCapTx({
-          tokenId,
+          tokenAddress,
           recipientAddress,
           sender: address,
         });

--- a/apps/maestro/src/features/ManageInterchainToken/hooks/useTransferTreasuryCapMutation.ts
+++ b/apps/maestro/src/features/ManageInterchainToken/hooks/useTransferTreasuryCapMutation.ts
@@ -1,0 +1,72 @@
+import { useSignAndExecuteTransaction } from "@mysten/dapp-kit";
+
+import { suiClient as client } from "~/lib/clients/suiClient";
+import { useAccount, useChainId } from "~/lib/hooks";
+import { useTransactionState } from "~/lib/hooks/useTransactionState";
+import { trpc } from "~/lib/trpc";
+
+export function useTransferTreasuryCapMutation() {
+  const [txState, setTxState] = useTransactionState();
+  const chainId = useChainId();
+  const { address } = useAccount();
+
+  const { mutateAsync: getTransferTreasuryCapTx } =
+    trpc.sui.getTransferTreasuryCapTx.useMutation({
+      onError(error) {
+        console.log("error in getTransferTreasuryCapTx", error.message);
+      },
+    });
+
+  const { mutateAsync: signAndExecuteTransaction } =
+    useSignAndExecuteTransaction({
+      execute: async ({ bytes, signature }) => {
+        const result = await client.executeTransactionBlock({
+          transactionBlock: bytes,
+          signature,
+          options: {
+            showObjectChanges: true,
+            showEvents: true,
+            showEffects: true,
+            showRawEffects: true,
+          },
+        });
+        return result;
+      },
+    });
+
+  return {
+    txState,
+    setTxState,
+    transferTreasuryCap: async (tokenId: string, recipientAddress: string) => {
+      if (!address) return;
+
+      try {
+        setTxState({
+          status: "awaiting_approval",
+        });
+
+        const treasuryCapTxJSON = await getTransferTreasuryCapTx({
+          tokenId,
+          recipientAddress,
+          sender: address,
+        });
+
+        const result = await signAndExecuteTransaction({
+          transaction: treasuryCapTxJSON,
+        });
+
+        setTxState({
+          status: "submitted",
+          hash: result.digest,
+          chainId,
+          suiTx: result,
+        });
+
+        return result;
+      } catch (error) {
+        console.error("Failed to transfer treasury cap:", error);
+        throw error;
+      }
+    },
+  };
+}

--- a/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
+++ b/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
@@ -97,11 +97,15 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
       deploymentTxHash: digest,
     }));
     console.log("remoteTokens", remoteTokens);
+   const txIndex = txState.suiTx?.events?.[2]?.id?.eventSeq ?? 0; // TODO: find the correct txIndex, it seems to be always 3
+
+    // fix hardcoded value
     await recordRemoteTokenDeployment({
       tokenAddress: props.tokenAddress,
       chainId: props.originChainId ?? -1,
+      axelarChainId: "sui",
       // TODO: find event Txindex correctly
-      deploymentMessageId: `${digest}`,
+      deploymentMessageId: `${digest}-${txIndex}`,
       remoteTokens,
     });
     console.log("setTxState");
@@ -199,10 +203,11 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
     const txPromise = registerTokensAsync();
 
     await handleTransactionResult(txPromise, {
-      onSuccess(txHash) {
+      onSuccess(result) {
         setTxState({
           status: "submitted",
-          hash: txHash,
+          hash: result?.digest || txHash,
+          suiTx: result,
           chainId: props.originChainId ?? -1,
           txType: "INTERCHAIN_DEPLOYMENT",
         });

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokenOnSui.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokenOnSui.ts
@@ -1,6 +1,4 @@
 import { useSignAndExecuteTransaction } from "@mysten/dapp-kit";
-import { Transaction } from "@mysten/sui/transactions";
-import { fromHex } from "@mysten/sui/utils";
 
 import { suiClient as client } from "~/lib/clients/suiClient";
 import { useAccount } from "~/lib/hooks";

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokenOnSui.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokenOnSui.ts
@@ -1,0 +1,79 @@
+import { useSignAndExecuteTransaction } from "@mysten/dapp-kit";
+import { Transaction } from "@mysten/sui/transactions";
+import { fromHex } from "@mysten/sui/utils";
+
+import { suiClient as client } from "~/lib/clients/suiClient";
+import { useAccount } from "~/lib/hooks";
+import { trpc } from "~/lib/trpc";
+
+type RegisterRemoteInterchainTokenOnSuiInput ={
+  axelarChainIds: string[];
+  originChainId: number;
+  tokenAddress: string;
+  symbol: string;
+};
+
+export function useRegisterRemoteInterchainTokenOnSui() {
+  const currentAccount = useAccount();
+  const { mutateAsync: signAndExecuteTransaction } =
+    useSignAndExecuteTransaction({
+      execute: async ({ bytes, signature }) => {
+        const result = await client.executeTransactionBlock({
+          transactionBlock: bytes,
+          signature,
+          options: {
+            showObjectChanges: true,
+            showEvents: true,
+            showEffects: true,
+            showRawEffects: true,
+          },
+        });
+        return result;
+      },
+    });
+
+  const { mutateAsync: getRegisterRemoteInterchainTokenTx } =
+    trpc.sui.getRegisterRemoteInterchainTokenTx.useMutation({
+      onError(error) {
+        console.log(
+          "error in getRegisterRemoteInterchainTokenTx",
+          error.message
+        );
+      },
+    });
+
+  const registerRemoteInterchainToken = async (
+    input: RegisterRemoteInterchainTokenOnSuiInput
+  ) => {
+    if (!currentAccount) {
+      throw new Error("Wallet not connected");
+    }
+
+    try {
+      const registerTokenTxJSON =
+        await getRegisterRemoteInterchainTokenTx({
+          tokenAddress: input.tokenAddress,
+          destinationChainIds: input.axelarChainIds,
+          originChainId: input.originChainId,
+          sender: currentAccount.address,
+          symbol: input.symbol,
+        });
+
+      const registerTokenResult = await signAndExecuteTransaction({
+        transaction: registerTokenTxJSON,
+      });
+
+      return registerTokenResult;
+    } catch (error) {
+      console.error("Register remote token failed:", error);
+      throw error;
+    }
+  };
+
+  return {
+    registerRemoteInterchainToken,
+    isConnected: !!currentAccount,
+    account: currentAccount,
+  };
+}
+

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
@@ -100,7 +100,7 @@ export default function useRegisterRemoteInterchainTokens(
     ...mutation,
     writeContract: () => {
       if (chainId === SUI_CHAIN_ID) {
-        return registerRemoteInterchainToken(suiInput).then(receipt => receipt);
+        return registerRemoteInterchainToken(suiInput);
       }
 
       if (!config) return;
@@ -109,7 +109,7 @@ export default function useRegisterRemoteInterchainTokens(
     },
     writeContractAsync: async () => {
       if (chainId === SUI_CHAIN_ID) {
-        return registerRemoteInterchainToken(suiInput).then(receipt => receipt);
+        return registerRemoteInterchainToken(suiInput);
       }
 
       if (!config) return;

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
@@ -9,10 +9,11 @@ import {
   useSimulateInterchainTokenFactoryMulticall,
   useWriteInterchainTokenFactoryMulticall,
 } from "~/lib/contracts/InterchainTokenFactory.hooks";
-import { useChainId } from "~/lib/hooks";
+import { SUI_CHAIN_ID, useChainId } from "~/lib/hooks";
 import { useEstimateGasFeeMultipleChainsQuery } from "~/services/axelarjsSDK/hooks";
 import { useAllChainConfigsQuery } from "~/services/axelarscan/hooks";
 import { useInterchainTokenDetailsQuery } from "~/services/interchainToken/hooks";
+import { useRegisterRemoteInterchainTokenOnSui } from "./useRegisterRemoteInterchainTokenOnSui";
 
 export type RegisterRemoteInterchainTokensInput = {
   chainIds: number[];
@@ -35,9 +36,7 @@ export default function useRegisterRemoteInterchainTokens(
     [input.chainIds, combinedComputed.indexedByChainId]
   );
 
-  const destinationChainIds = destinationChains.map(
-    (chain) => chain.id
-  );
+  const destinationChainIds = destinationChains.map((chain) => chain.id);
 
   const sourceChain = useMemo(
     () => combinedComputed.indexedByChainId[chainId],
@@ -80,20 +79,39 @@ export default function useRegisterRemoteInterchainTokens(
     value: totalGasFee,
     args: [multicallArgs],
     query: {
-      enabled: multicallArgs.length > 0,
+      enabled: chainId !== SUI_CHAIN_ID && multicallArgs.length > 0,
     },
   });
 
   const mutation = useWriteInterchainTokenFactoryMulticall();
 
+  const { registerRemoteInterchainToken } =
+    useRegisterRemoteInterchainTokenOnSui();
+
+  if (!tokenDeployment) return;
+  const suiInput = {
+    axelarChainIds: destinationChainIds,
+    originChainId: input.originChainId,
+    tokenAddress: input.tokenAddress,
+    symbol: tokenDeployment.tokenSymbol,
+  };
+
   return {
     ...mutation,
     writeContract: () => {
+      if (chainId === SUI_CHAIN_ID) {
+        return registerRemoteInterchainToken(suiInput).then(receipt => receipt.digest);
+      }
+
       if (!config) return;
 
       return mutation.writeContract(config.request);
     },
     writeContractAsync: async () => {
+      if (chainId === SUI_CHAIN_ID) {
+        return registerRemoteInterchainToken(suiInput).then(receipt => receipt.digest);
+      }
+
       if (!config) return;
 
       return await mutation.writeContractAsync(config.request);

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
@@ -100,7 +100,7 @@ export default function useRegisterRemoteInterchainTokens(
     ...mutation,
     writeContract: () => {
       if (chainId === SUI_CHAIN_ID) {
-        return registerRemoteInterchainToken(suiInput).then(receipt => receipt.digest);
+        return registerRemoteInterchainToken(suiInput).then(receipt => receipt);
       }
 
       if (!config) return;
@@ -109,7 +109,7 @@ export default function useRegisterRemoteInterchainTokens(
     },
     writeContractAsync: async () => {
       if (chainId === SUI_CHAIN_ID) {
-        return registerRemoteInterchainToken(suiInput).then(receipt => receipt.digest);
+        return registerRemoteInterchainToken(suiInput).then(receipt => receipt);
       }
 
       if (!config) return;

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
@@ -15,11 +15,15 @@ import { useCallback, useEffect, useMemo, type FC } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 
 import type { SuiTransactionBlockResponse } from "@mysten/sui/client";
+import { isValidSuiAddress } from "@mysten/sui/utils";
 import { formatUnits, parseUnits } from "viem";
 
 import { useAccount } from "~/lib/hooks";
 import { logger } from "~/lib/logger";
-import { preventNonNumericInput } from "~/lib/utils/validation";
+import {
+  isValidEVMAddress,
+  preventNonNumericInput,
+} from "~/lib/utils/validation";
 import BigNumberText from "~/ui/components/BigNumberText";
 import ChainsDropdown from "~/ui/components/ChainsDropdown";
 import GMPTxStatusMonitor from "~/ui/compounds/GMPTxStatusMonitor";
@@ -271,11 +275,9 @@ export const SendInterchainToken: FC<Props> = (props) => {
   }, [state.selectedToChain?.chain_type, props.sourceChain.chain_type]);
 
   useEffect(() => {
-    if (isEvmChainsOnly) {
-      setValue("destinationAddress", address ?? "", {
-        shouldValidate: true,
-      });
-    }
+    setValue("destinationAddress", address ?? "", {
+      shouldValidate: true,
+    });
   }, [
     state.selectedToChain?.chain_type,
     props.sourceChain.chain_type,
@@ -415,9 +417,22 @@ export const SendInterchainToken: FC<Props> = (props) => {
               {...register("destinationAddress", {
                 required: "Destination address is required",
                 validate: (value) => {
-                  if (value.length < 42) {
-                    return "Invalid address length";
+                  // TODO handle sui address length
+                  console.log("select to chain", state.selectedToChain);
+                  if (
+                    state.selectedToChain.id === "sui" &&
+                    !isValidSuiAddress(value)
+                  ) {
+                    return "Invalid SUI address";
                   }
+
+                  if (
+                    state.selectedToChain.chain_type === "evm" &&
+                    !isValidEVMAddress(value)
+                  ) {
+                    return "Invalid EVM address";
+                  }
+
                   return true;
                 },
               })}

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
@@ -267,23 +267,24 @@ export const SendInterchainToken: FC<Props> = (props) => {
     });
   }, [props.balance.decimals, props.balance.tokenBalance, setValue]);
 
-  const isEvmChainsOnly = useMemo(() => {
+  const isSameChainType = useMemo(() => {
     return (
-      state.selectedToChain?.chain_type === "evm" &&
-      props.sourceChain.chain_type === "evm"
+      state.selectedToChain?.chain_type === props.sourceChain.chain_type
     );
   }, [state.selectedToChain?.chain_type, props.sourceChain.chain_type]);
 
   useEffect(() => {
-    setValue("destinationAddress", address ?? "", {
+    const defaultAddress = isSameChainType ? (address ?? "") : "";
+
+    setValue("destinationAddress", defaultAddress, {
       shouldValidate: true,
     });
   }, [
     state.selectedToChain?.chain_type,
-    props.sourceChain.chain_type,
+    props.sourceChain?.chain_type,
     address,
     setValue,
-    isEvmChainsOnly,
+    isSameChainType,
   ]);
 
   return (
@@ -404,7 +405,7 @@ export const SendInterchainToken: FC<Props> = (props) => {
           <FormControl>
             <Label htmlFor="destinationAddress">
               <Label.Text>Destination Address</Label.Text>
-              {isEvmChainsOnly && (
+              {isSameChainType && (
                 <Label.AltText>(Using connected wallet address)</Label.AltText>
               )}
             </Label>
@@ -413,7 +414,7 @@ export const SendInterchainToken: FC<Props> = (props) => {
               $bordered
               placeholder="Enter destination address"
               className="bg-base-200"
-              disabled={isEvmChainsOnly}
+              disabled={isSameChainType}
               {...register("destinationAddress", {
                 required: "Destination address is required",
                 validate: (value) => {

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
@@ -268,9 +268,7 @@ export const SendInterchainToken: FC<Props> = (props) => {
   }, [props.balance.decimals, props.balance.tokenBalance, setValue]);
 
   const isSameChainType = useMemo(() => {
-    return (
-      state.selectedToChain?.chain_type === props.sourceChain.chain_type
-    );
+    return state.selectedToChain?.chain_type === props.sourceChain.chain_type;
   }, [state.selectedToChain?.chain_type, props.sourceChain.chain_type]);
 
   useEffect(() => {
@@ -414,6 +412,11 @@ export const SendInterchainToken: FC<Props> = (props) => {
               $bordered
               placeholder="Enter destination address"
               className="bg-base-200"
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
+              aria-autocomplete="none"
               disabled={isSameChainType}
               {...register("destinationAddress", {
                 required: "Destination address is required",

--- a/apps/maestro/src/server/routers/erc20/getERC20TokenBalanceForOwner.ts
+++ b/apps/maestro/src/server/routers/erc20/getERC20TokenBalanceForOwner.ts
@@ -52,7 +52,12 @@ export const getERC20TokenBalanceForOwner = publicProcedure
       // Get the coin metadata
       const metadata = await client.getCoinMetadata({ coinType });
 
-      const tokenOwner = await getTokenOwner(input.tokenAddress);
+      let tokenOwner = null;
+      try {
+        tokenOwner = await getTokenOwner(input.tokenAddress);
+      } catch (error) {
+        console.log("getERC20TokenBalanceForOwner", error);
+      }
 
       isTokenOwner = tokenOwner === input.owner;
 

--- a/apps/maestro/src/server/routers/erc20/getERC20TokenBalanceForOwner.ts
+++ b/apps/maestro/src/server/routers/erc20/getERC20TokenBalanceForOwner.ts
@@ -53,6 +53,7 @@ export const getERC20TokenBalanceForOwner = publicProcedure
       const metadata = await client.getCoinMetadata({ coinType });
 
       let tokenOwner = null;
+      // TODO: address this properly
       try {
         tokenOwner = await getTokenOwner(input.tokenAddress);
       } catch (error) {

--- a/apps/maestro/src/server/routers/gmp/getTransactionStatusesOnDestinationChains.ts
+++ b/apps/maestro/src/server/routers/gmp/getTransactionStatusesOnDestinationChains.ts
@@ -53,7 +53,7 @@ async function processGMPData(
 export const getTransactionStatusesOnDestinationChains = publicProcedure
   .input(
     z.object({
-      txHashes: z.array(hex64Literal()),
+      txHashes: z.array(z.string()),
     })
   )
   .query(async ({ ctx, input }) => {

--- a/apps/maestro/src/server/routers/gmp/getTransactionStatusesOnDestinationChains.ts
+++ b/apps/maestro/src/server/routers/gmp/getTransactionStatusesOnDestinationChains.ts
@@ -3,9 +3,11 @@ import type { GMPTxStatus } from "@axelarjs/api";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { hex64Literal } from "~/lib/utils/validation";
 import { publicProcedure } from "~/server/trpc";
-import { SEARCHGMP_SOURCE, ChainStatus } from "./getTransactionStatusOnDestinationChains";
+import {
+  ChainStatus,
+  SEARCHGMP_SOURCE,
+} from "./getTransactionStatusOnDestinationChains";
 
 async function getSecondHopStatus(
   messageId: string,

--- a/apps/maestro/src/server/routers/interchainToken/recordInterchainTokenDeployment.ts
+++ b/apps/maestro/src/server/routers/interchainToken/recordInterchainTokenDeployment.ts
@@ -135,8 +135,7 @@ export const recordInterchainTokenDeployment = protectedProcedure
               })
               .catch(always("0x")),
             itsClient.reads
-              .registeredTokenAddress({
-                // this method will not always return the token address because it is not always already registered so we will have to update it later in the token details page
+              .interchainTokenAddress({
                 tokenId: input.tokenId as `0x${string}`,
               })
               .catch(always(input.tokenAddress)),

--- a/apps/maestro/src/server/routers/interchainToken/recordRemoteTokensDeployment.ts
+++ b/apps/maestro/src/server/routers/interchainToken/recordRemoteTokensDeployment.ts
@@ -28,8 +28,8 @@ export const recordRemoteTokensDeployment = protectedProcedure
 
     // Try to find config in either chain type
     // TODO: fix hardcoded value
-    const configs = evmChains[input.chainId] || vmChains[input?.axelarChainId || "sui"];
-
+    const configs =
+      evmChains[input.chainId] || vmChains[input?.axelarChainId || "sui"];
     if (!configs) {
       throw new TRPCError({
         code: "NOT_FOUND",
@@ -104,7 +104,7 @@ export const recordRemoteTokensDeployment = protectedProcedure
               })
               .catch(always("0x")),
             itsClient.reads
-              .registeredTokenAddress({
+              .interchainTokenAddress({
                 tokenId: originToken.tokenId as `0x${string}`,
               })
               .catch(always("0x")),
@@ -126,7 +126,7 @@ export const recordRemoteTokensDeployment = protectedProcedure
         };
       })
     );
-     
+
     return ctx.persistence.postgres.recordRemoteInterchainTokenDeployments(
       remoteTokens as NewRemoteInterchainTokenInput[]
     );

--- a/apps/maestro/src/server/routers/interchainToken/updateSuiRemoteTokenAddresses.ts
+++ b/apps/maestro/src/server/routers/interchainToken/updateSuiRemoteTokenAddresses.ts
@@ -8,8 +8,6 @@ export const updateSuiRemoteTokenAddresses = protectedProcedure
       tokenId: z.string(),
     })
   )
-  .mutation(async ({ ctx, input }) => {
-    return ctx.persistence.postgres.updateSuiRemoteTokenAddresses(
-      input.tokenId
-    );
-  });
+  .mutation(({ ctx, input }) =>
+    ctx.persistence.postgres.updateSuiRemoteTokenAddresses(input.tokenId)
+  );

--- a/apps/maestro/src/server/routers/sui/index.ts
+++ b/apps/maestro/src/server/routers/sui/index.ts
@@ -192,16 +192,10 @@ export const suiRouter = router({
         });
         const coinObjectId = coins.data[0].coinObjectId;
 
+
+
         // Split token to transfer to the destination chain
         const Coin = tx.splitCoins(coinObjectId, [BigInt(input.amount)]);
-
-        const coinMetadata = await suiClient.getCoinMetadata({
-          coinType: input.coinType,
-        });
-
-        if (!coinMetadata) {
-          throw new Error(`Coin metadata not found for ${input.coinType}`);
-        }
 
         const { Example, AxelarGateway, GasService, ITS } = chainConfig.contracts;
 
@@ -209,7 +203,6 @@ export const suiRouter = router({
           txBuilder,
           input.tokenId,
           ITS,
-          coinMetadata
         );
 
         await txBuilder.moveCall({

--- a/apps/maestro/src/server/routers/sui/index.ts
+++ b/apps/maestro/src/server/routers/sui/index.ts
@@ -294,27 +294,22 @@ export const suiRouter = router({
     .input(
       z.object({
         sender: z.string(),
-        tokenId: z.string(),
+        tokenAddress: z.string(),
         recipientAddress: z.string(),
       })
     )
     .mutation(async ({ input }) => {
       try {
-        const { sender, tokenId, recipientAddress } = input;
-        const treasuryCap = await getTreasuryCap(tokenId);
-
+        const { sender, tokenAddress, recipientAddress } = input;
+        const treasuryCap = await getTreasuryCap(tokenAddress);
         if (!treasuryCap) {
           throw new Error("Treasury cap not found");
         }
 
         const txBuilder = new TxBuilder(suiClient);
 
-        await txBuilder.moveCall({
-          target: `${SUI_PACKAGE_ID}::transfer::transfer`,
-          arguments: [treasuryCap, recipientAddress],
-        });
-
         const tx = await buildTx(sender, txBuilder);
+        tx.transferObjects([treasuryCap], tx.pure.address(recipientAddress));
         const txJSON = await tx.toJSON();
         return txJSON;
       } catch (error) {

--- a/apps/maestro/src/server/routers/sui/utils/txUtils.ts
+++ b/apps/maestro/src/server/routers/sui/utils/txUtils.ts
@@ -1,0 +1,72 @@
+import { TxBuilder } from "@axelar-network/axelar-cgp-sui";
+import { CoinMetadata } from "@mysten/sui/client";
+
+import { suiClient } from "~/lib/clients/suiClient";
+import { suiServiceBaseUrl } from "./utils";
+
+export async function getChainConfig() {
+  const response = await fetch(`${suiServiceBaseUrl}/chain/devnet-amplifier`);
+  const _chainConfig = await response.json();
+  return _chainConfig.chains.sui;
+}
+
+export function setupTxBuilder(sender: string, chainConfig: any) {
+  const txBuilder = new TxBuilder(suiClient);
+  txBuilder.tx.setSenderIfNotSet(sender);
+
+  const ITS = chainConfig.contracts.ITS;
+  const Example = chainConfig.contracts.Example;
+  const AxelarGateway = chainConfig.contracts.AxelarGateway;
+  const GasService = chainConfig.contracts.GasService;
+
+  return { txBuilder, ITS, Example, AxelarGateway, GasService };
+}
+
+export async function getTokenId(
+  txBuilder: TxBuilder,
+  tokenType: string,
+  ITS: any,
+  coinMetadata: CoinMetadata
+) {
+  const [TokenId] = await txBuilder.moveCall({
+    target: `${ITS.address}::token_id::from_info`,
+    typeArguments: [tokenType],
+    arguments: [
+      coinMetadata.name,
+      coinMetadata.symbol,
+      txBuilder.tx.pure.u8(coinMetadata.decimals),
+      txBuilder.tx.pure.bool(false),
+      txBuilder.tx.pure.bool(false),
+    ],
+  });
+  return TokenId;
+}
+
+export async function deployRemoteInterchainToken(
+  txBuilder: TxBuilder,
+  ITS: any,
+  AxelarGateway: any,
+  GasService: any,
+  destinationChain: string,
+  TokenId: any,
+  feeUnitAmount: number,
+  sender: string,
+  tokenType: string
+) {
+  const gas = txBuilder.tx.splitCoins(txBuilder.tx.gas, [feeUnitAmount]);
+
+  await txBuilder.moveCall({
+    target: `${ITS.address}::its::deploy_remote_interchain_token`,
+    arguments: [
+      ITS.objects.ITS,
+      AxelarGateway.objects.Gateway,
+      GasService.objects.GasService,
+      destinationChain,
+      TokenId,
+      gas,
+      "0x",
+      sender,
+    ],
+    typeArguments: [tokenType],
+  });
+}

--- a/apps/maestro/src/server/routers/sui/utils/txUtils.ts
+++ b/apps/maestro/src/server/routers/sui/utils/txUtils.ts
@@ -10,16 +10,11 @@ export async function getChainConfig() {
   return _chainConfig.chains.sui;
 }
 
-export function setupTxBuilder(sender: string, chainConfig: any) {
+export function setupTxBuilder(sender: string) {
   const txBuilder = new TxBuilder(suiClient);
   txBuilder.tx.setSenderIfNotSet(sender);
 
-  const ITS = chainConfig.contracts.ITS;
-  const Example = chainConfig.contracts.Example;
-  const AxelarGateway = chainConfig.contracts.AxelarGateway;
-  const GasService = chainConfig.contracts.GasService;
-
-  return { txBuilder, ITS, Example, AxelarGateway, GasService };
+  return { txBuilder };
 }
 
 export async function getTokenId(
@@ -44,17 +39,17 @@ export async function getTokenId(
 
 export async function deployRemoteInterchainToken(
   txBuilder: TxBuilder,
-  ITS: any,
-  AxelarGateway: any,
-  GasService: any,
-  Example: any,
+  chainConfig: any,
   destinationChain: string,
-  TokenId: any,
+  coinMetadata: any,
   feeUnitAmount: number,
   sender: string,
   tokenType: string
 ) {
+  const { Example, ITS, AxelarGateway, GasService } = chainConfig.contracts;
   const gas = txBuilder.tx.splitCoins(txBuilder.tx.gas, [feeUnitAmount]);
+
+  const TokenId = await getTokenId(txBuilder, tokenType, ITS, coinMetadata);
 
   await txBuilder.moveCall({
     target: `${Example.address}::its::deploy_remote_interchain_token`,

--- a/apps/maestro/src/server/routers/sui/utils/txUtils.ts
+++ b/apps/maestro/src/server/routers/sui/utils/txUtils.ts
@@ -47,6 +47,7 @@ export async function deployRemoteInterchainToken(
   ITS: any,
   AxelarGateway: any,
   GasService: any,
+  Example: any,
   destinationChain: string,
   TokenId: any,
   feeUnitAmount: number,
@@ -56,7 +57,7 @@ export async function deployRemoteInterchainToken(
   const gas = txBuilder.tx.splitCoins(txBuilder.tx.gas, [feeUnitAmount]);
 
   await txBuilder.moveCall({
-    target: `${ITS.address}::its::deploy_remote_interchain_token`,
+    target: `${Example.address}::its::deploy_remote_interchain_token`,
     arguments: [
       ITS.objects.ITS,
       AxelarGateway.objects.Gateway,

--- a/apps/maestro/src/server/routers/sui/utils/utils.ts
+++ b/apps/maestro/src/server/routers/sui/utils/utils.ts
@@ -270,5 +270,5 @@ function extractCoinInfo(coin: SuiObjectResponse) {
     symbol: coinInfo.symbol,
     totalSupply: coinManagement.treasury_cap.fields.total_supply.fields.value,
     treasuryCap: coinManagement.treasury_cap.fields.id.id,
-  }
+  };
 }

--- a/apps/maestro/src/server/routers/sui/utils/utils.ts
+++ b/apps/maestro/src/server/routers/sui/utils/utils.ts
@@ -208,8 +208,8 @@ function extractTokenDetails(filteredResult: DynamicFieldInfo) {
 }
 
 function extractCoinInfo(coin: SuiObjectResponse) {
-  // Extract the token manager (objectId)
-  const fields = coin.data?.content?.fields?.value?.fields;
+  const content = coin.data?.content as any;
+  const fields = content?.fields?.value?.fields;
   const coinInfo = fields?.coin_info.fields;
   const coinManagement = fields?.coin_management.fields;
 

--- a/apps/maestro/src/services/gmp/hooks.ts
+++ b/apps/maestro/src/services/gmp/hooks.ts
@@ -103,7 +103,7 @@ export function useGetTransactionsStatusesOnDestinationChainsQuery(
       },
       {
         enabled: Boolean(
-          input.txHashes?.every((txHash) => txHash.match(/^(0x)?[0-9a-f]{64}/i))
+          input.txHashes?.every((txHash) => txHash)
         ),
         refetchInterval: 1000 * 10,
         ...options,

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
@@ -396,7 +396,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
     isRestrictedToDeployer ||
     !address ||
     isGasPriceQueryLoading ||
-    !hasFetchedStatuses;
+    (sessionState.deployTokensTxHashes.length && !hasFetchedStatuses);
 
   const shouldRenderFooter =
     !isReadOnly && nonRunningSelectedChainIds.length > 0;

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
@@ -27,7 +27,7 @@ import { createWalletClient, custom } from "viem";
 import { watchAsset } from "viem/actions";
 import { z } from "zod";
 
-import { useAccount } from "~/lib/hooks";
+import { SUI_CHAIN_ID, useAccount } from "~/lib/hooks";
 import { trpc } from "~/lib/trpc";
 import { hex64Literal } from "~/lib/utils/validation";
 import { ChainIcon } from "~/ui/components/ChainsDropdown";
@@ -74,32 +74,36 @@ const TokenDetailsSection: FC<TokenDetailsSectionProps> = (props) => {
         {maskAddress(props.tokenAddress)}
       </CopyToClipboardButton>,
     ],
-    [
-      "Add Token to Wallet",
-      <LinkButton
-        key="add-to-wallet"
-        href="#"
-        className="ml-[-10px]"
-        $variant="link"
-        onClick={async () => {
-          try {
-            await watchAsset(wallet, {
-              type: "ERC20",
-              options: {
-                address: props.tokenAddress,
-                decimals: props.decimals,
-                symbol: props.symbol,
-                image: meta?.iconUrl,
-              },
-            });
-          } catch (_e) {
-            // noop because the error is raised when the user cancels the popup dialog
-          }
-        }}
-      >
-        Add
-      </LinkButton>,
-    ],
+    ...(props.chain.chain_id !== SUI_CHAIN_ID
+      ? [
+          [
+            "Add Token to Wallet",
+            <LinkButton
+              key="add-to-wallet"
+              href="#"
+              className="ml-[-10px]"
+              $variant="link"
+              onClick={async () => {
+                try {
+                  await watchAsset(wallet, {
+                    type: "ERC20",
+                    options: {
+                      address: props.tokenAddress,
+                      decimals: props.decimals,
+                      symbol: props.symbol,
+                      image: meta?.iconUrl,
+                    },
+                  });
+                } catch (_e) {
+                  // noop because the error is raised when the user cancels the popup dialog
+                }
+              }}
+            >
+              Add
+            </LinkButton>,
+          ],
+        ]
+      : []),
     ...Maybe.of(props.tokenManagerAddress).mapOr([], (tokenManagerAddress) =>
       !props.deploymentMessageId
         ? [[]]


### PR DESCRIPTION
# Description

This PR supports token deployment from the token details page and fix various issues related to token transfer

## Changes

- Support token deployment from the token details page [AXE-7558](https://axelarnetwork.atlassian.net/browse/AXE-7658)
- Fix Sui balance doesn't show when Sui is the remote chain [AXE-7657](https://axelarnetwork.atlassian.net/browse/AXE-7657)
- Validate Sui address when transfer the token [AXE-7664](https://axelarnetwork.atlassian.net/browse/AXE-7664)
- Don't prefill destination address when the connected wallet address is not compatible with destination chain [AXE-7670](https://axelarnetwork.atlassian.net/browse/AXE-7670)
- Fix wrong sui token decimals [AXE-7671](https://axelarnetwork.atlassian.net/browse/AXE-7671)
- Disable autocomplete on destination address input in transfer form
- Fix cannot transfer token from sui remote chain to other chain [AXE-7673](https://axelarnetwork.atlassian.net/browse/AXE-7673)

# WIP

- [x] Able to send token deployment from token details page
- [x] Record registration info into the db
- [ ] Fix build error


[AXE-7558]: https://axelarnetwork.atlassian.net/browse/AXE-7558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AXE-7657]: https://axelarnetwork.atlassian.net/browse/AXE-7657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AXE-7664]: https://axelarnetwork.atlassian.net/browse/AXE-7664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AXE-7670]: https://axelarnetwork.atlassian.net/browse/AXE-7670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AXE-7671]: https://axelarnetwork.atlassian.net/browse/AXE-7671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AXE-7673]: https://axelarnetwork.atlassian.net/browse/AXE-7673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ