### PR TITLE
chore: fix sui deployment

### DIFF
--- a/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
+++ b/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
@@ -8,6 +8,7 @@ import type { TransactionReceipt } from "viem";
 import { useWaitForTransactionReceipt } from "wagmi";
 import { GetBalanceReturnType } from "wagmi/actions";
 
+import { suiChainConfig } from "~/config/chains";
 import { useAccount } from "~/lib/hooks";
 import {
   useTransactionState,
@@ -18,7 +19,6 @@ import { trpc } from "~/lib/trpc";
 import { useAllChainConfigsQuery } from "~/services/axelarscan/hooks";
 import useRegisterRemoteCanonicalTokens from "./hooks/useRegisterRemoteCanonicalTokens";
 import useRegisterRemoteInterchainTokens from "./hooks/useRegisterRemoteInterchainTokens";
-import { suiChainConfig } from "~/config/chains";
 
 export type RegisterRemoteTokensProps = {
   tokenAddress: string;
@@ -191,15 +191,17 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
   ]);
 
   const handleClick = useCallback(async () => {
-    if (!registerTokensAsync) return;
-
-    setTxState({
-      status: "awaiting_approval",
-    });
-
-    const txPromise = registerTokensAsync();
-
     try {
+      if (!registerTokensAsync) {
+        throw new Error("registerTokensAsync is not defined");
+      }
+
+      setTxState({
+        status: "awaiting_approval",
+      });
+
+      const txPromise = registerTokensAsync();
+
       const result = await txPromise;
       setTxState({
         status: "submitted",

--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -213,7 +213,7 @@ async function getInterchainToken(
         } else if (chainConfig?.axelarChainId.includes("sui")) {
           const suiTxHash = await findSuiTxHashFromGmp(
             ctx,
-            tokenDetails.deploymentMessageId
+            remoteToken.deploymentMessageId
           );
 
           if (!suiTxHash) {
@@ -224,7 +224,7 @@ async function getInterchainToken(
           }
 
           const { isRegistered, tokenAddress } =
-            await getSuiTokenRegistrationDetails(suiTxHash, remoteTokenDetails);
+          await getSuiTokenRegistrationDetails(suiTxHash, remoteTokenDetails);
 
           return {
             ...remoteTokenDetails,


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-8106

This PR fixes the bug where the destination sui chain doesn't move from pending to registered state. 

Another change is to wrap the whole `handleClick` function for submit additional token register chain button into the `try-catch` block to make sure that whatever errors that throws out of the function will be handled gracefully.

## Investigation Result

it happens when the tx for token register at the origin chain and the tx for remote token register are different. when the destination chain is sui, it uses the `deploymentMessageId` to search for executed tx hash at sui chain. however, there’re two types of `deploymentMessageId` in this case which are:
- `deploymentMessageId`  for token register at the source chain which is a non-gmp call
- `deploymentMessageId` for remote token register which is a gmp call.

The bug happens because it uses the first `deploymentMessageId`  for the `searchGMP` api to find the executed tx hash and it doesn’t exist because it’s non-gmp call. I’ve fixed it to use the second one now, so the issue should be resolved.