### PR TITLE
chore: update axelar configs url devnet

### DIFF
--- a/packages/api/src/axelar-config/isomorphic.ts
+++ b/packages/api/src/axelar-config/isomorphic.ts
@@ -12,14 +12,8 @@ export class AxelarConfigClient extends RestService {
   }
 
   async getAxelarConfigs(env: Environment) {
-    // TODO: use 1.x for all envs once ayush fixes the config
-    const fileName =
-      env === "devnet-amplifier"
-        ? `configs/${env}-config-1.0.x.json`
-        : `configs/${env}-config-1.x.json`;
-
     return this.client
-      .get(fileName)
+      .get(`configs/${env}-config-1.x.json`)
       .json<AxelarConfigsResponse>();
   }
 


### PR DESCRIPTION
# Description

We don't need to separate the url for `devnet-amplifier` since both `1.x` and `1.0.x` include `sui-2` now.