### PR TITLE
fix: transfers modal set address for evm

### DIFF
--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.tsx
@@ -307,6 +307,8 @@ export const SendInterchainToken: FC<Props> = (props) => {
           props.onClose?.();
           resetForm();
           actions.resetTxState();
+        } else if (isSameAddress) {
+          setValue("destinationAddress", address ?? "");
         }
         actions.setIsModalOpen(isOpen);
       }}


### PR DESCRIPTION
Fixes a bug where when closing and reopening the transfer modal, the address is not being set and for evm->evm transfers, you can't edit the field so there's nothing you can do.