### PR TITLE
fix: use chain config for stellar rpc url

### DIFF
--- a/.changeset/chatty-cherries-fail.md
+++ b/.changeset/chatty-cherries-fail.md
@@ -1,0 +1,5 @@
+---
+"@axelarjs/core": patch
+---
+
+update rpc url for stellar mainnet

--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -480,7 +480,7 @@ export async function getStellarTokenRegistrationDetails(
 }> {
   try {
     const chainConfig = await getStellarChainConfig(ctx);
-    const rpcUrl = STELLAR_RPC_URLS[NEXT_PUBLIC_NETWORK_ENV];
+    const rpcUrl = chainConfig.config.rpc[0];
     // Create a network-configured Stellar contract client
     const ITSStellarContractClient = (await Client.from({
       contractId: chainConfig.config.contracts.InterchainTokenService.address,

--- a/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
+++ b/apps/maestro/src/server/routers/interchainToken/searchInterchainToken.ts
@@ -1,4 +1,3 @@
-import { STELLAR_RPC_URLS } from "@axelarjs/core";
 import { invariant } from "@axelarjs/utils";
 
 import { TRPCError } from "@trpc/server";
@@ -7,10 +6,7 @@ import { Client } from "stellar-sdk/contract";
 import { z } from "zod";
 
 import type { ExtendedWagmiChainConfig } from "~/config/chains";
-import {
-  NEXT_PUBLIC_NETWORK_ENV,
-  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE,
-} from "~/config/env";
+import { NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE } from "~/config/env";
 import { suiClient } from "~/lib/clients/suiClient";
 import { InterchainToken, RemoteInterchainToken } from "~/lib/drizzle/schema";
 import { TOKEN_MANAGER_TYPES } from "~/lib/drizzle/schema/common";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,5 +127,5 @@ export const SUI_RPC_URLS = {
 export const STELLAR_RPC_URLS = {
   "devnet-amplifier": "https://soroban-testnet.stellar.org",
   testnet: "https://soroban-testnet.stellar.org",
-  mainnet: "https://soroban-rpc.stellar.org",
+  mainnet: "https://mainnet.sorobanrpc.com",
 };


### PR DESCRIPTION
# Description

Fix the token details page cannot render stellar as a remote registered chain properly due to invalid rpc url