### PR TITLE
chore: prevent reading undefined tokenid for token images

### DIFF
--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/TokenDetailsSection.tsx
@@ -361,7 +361,9 @@ export const TokenIcon: FC<{ tokenId: `0x${string}` }> = ({ tokenId }) => {
           layout="fill"
         />
       ) : (
-        <Identicon seed={jsNumberForAddress(tokenId)} diameter={36} />
+        tokenId && (
+          <Identicon seed={jsNumberForAddress(tokenId)} diameter={36} />
+        )
       )}
     </div>
   );


### PR DESCRIPTION
undefined token id values were being read and caused an error on the homepage