### PR TITLE
Update ITS portal deployment method

### DIFF
--- a/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
+++ b/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
@@ -139,11 +139,11 @@ export function useDeployAndRegisterRemoteInterchainTokenMutation(
     }
 
     const registerTxData = destinationChainIds.map((destinationChain, i) =>
-      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainToken2.data({
-        ...commonArgs,
-        originalChainName: "",
-        minter: minter as `0x${string}`,
+      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainTokenWithMinter.data({
+        salt: input.salt,
+        minter: "0x0000000000000000000000000000000000000000", // No minter set for security benefits
         destinationChain,
+        destinationMinter: "0x0000000000000000000000000000000000000000", // No destination minter set
         gasValue: input.remoteDeploymentGasFees?.gasFees?.[i].fee ?? 0n,
       })
     );

--- a/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
+++ b/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
@@ -139,11 +139,9 @@ export function useDeployAndRegisterRemoteInterchainTokenMutation(
     }
 
     const registerTxData = destinationChainIds.map((destinationChain, i) =>
-      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainTokenWithMinter.data({
+      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainToken.data({
         salt: input.salt,
-        minter: "0x0000000000000000000000000000000000000000", // No minter set for security benefits
         destinationChain,
-        destinationMinter: "0x0000000000000000000000000000000000000000", // No destination minter set
         gasValue: input.remoteDeploymentGasFees?.gasFees?.[i].fee ?? 0n,
       })
     );

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
@@ -67,11 +67,9 @@ export default function useRegisterRemoteInterchainTokens(
       return [];
 
     return destinationChainIds.map((chainId, i) =>
-      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainTokenWithMinter.data({
+      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainToken.data({
         salt: tokenDeployment.salt,
-        minter: "0x0000000000000000000000000000000000000000", // No minter set for security benefits
         destinationChain: chainId,
-        destinationMinter: "0x0000000000000000000000000000000000000000", // No destination minter set
         gasValue: gasFeesData.gasFees[i].fee,
       })
     );

--- a/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
+++ b/apps/maestro/src/features/RegisterRemoteTokens/hooks/useRegisterRemoteInterchainTokens.ts
@@ -67,9 +67,11 @@ export default function useRegisterRemoteInterchainTokens(
       return [];
 
     return destinationChainIds.map((chainId, i) =>
-      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainToken.data({
+      INTERCHAIN_TOKEN_FACTORY_ENCODERS.deployRemoteInterchainTokenWithMinter.data({
         salt: tokenDeployment.salt,
+        minter: "0x0000000000000000000000000000000000000000", // No minter set for security benefits
         destinationChain: chainId,
+        destinationMinter: "0x0000000000000000000000000000000000000000", // No destination minter set
         gasValue: gasFeesData.gasFees[i].fee,
       })
     );

--- a/apps/maestro/src/lib/contracts/InterchainTokenFactory.hooks.ts
+++ b/apps/maestro/src/lib/contracts/InterchainTokenFactory.hooks.ts
@@ -477,14 +477,6 @@ export const interchainTokenFactoryAbi = [
   },
 ] as const;
 
-export const interchainTokenFactoryAddress =
-  "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66" as const;
-
-export const interchainTokenFactoryConfig = {
-  address: interchainTokenFactoryAddress,
-  abi: interchainTokenFactoryAbi,
-} as const;
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // React
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -493,10 +485,7 @@ export const interchainTokenFactoryConfig = {
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link interchainTokenFactoryAbi}__
  */
 export const useReadInterchainTokenFactory =
-  /*#__PURE__*/ createUseReadContract({
-    abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
-  });
+  /*#__PURE__*/ createUseReadContract({ abi: interchainTokenFactoryAbi });
 
 /**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link interchainTokenFactoryAbi}__ and `functionName` set to `"canonicalInterchainTokenDeploySalt"`
@@ -504,7 +493,6 @@ export const useReadInterchainTokenFactory =
 export const useReadInterchainTokenFactoryCanonicalInterchainTokenDeploySalt =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "canonicalInterchainTokenDeploySalt",
   });
 
@@ -514,7 +502,6 @@ export const useReadInterchainTokenFactoryCanonicalInterchainTokenDeploySalt =
 export const useReadInterchainTokenFactoryCanonicalInterchainTokenId =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "canonicalInterchainTokenId",
   });
 
@@ -524,7 +511,6 @@ export const useReadInterchainTokenFactoryCanonicalInterchainTokenId =
 export const useReadInterchainTokenFactoryChainNameHash =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "chainNameHash",
   });
 
@@ -534,7 +520,6 @@ export const useReadInterchainTokenFactoryChainNameHash =
 export const useReadInterchainTokenFactoryContractId =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "contractId",
   });
 
@@ -544,7 +529,6 @@ export const useReadInterchainTokenFactoryContractId =
 export const useReadInterchainTokenFactoryImplementation =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "implementation",
   });
 
@@ -554,7 +538,6 @@ export const useReadInterchainTokenFactoryImplementation =
 export const useReadInterchainTokenFactoryInterchainTokenDeploySalt =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "interchainTokenDeploySalt",
   });
 
@@ -564,7 +547,6 @@ export const useReadInterchainTokenFactoryInterchainTokenDeploySalt =
 export const useReadInterchainTokenFactoryInterchainTokenId =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "interchainTokenId",
   });
 
@@ -574,7 +556,6 @@ export const useReadInterchainTokenFactoryInterchainTokenId =
 export const useReadInterchainTokenFactoryInterchainTokenService =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "interchainTokenService",
   });
 
@@ -584,7 +565,6 @@ export const useReadInterchainTokenFactoryInterchainTokenService =
 export const useReadInterchainTokenFactoryLinkedTokenDeploySalt =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "linkedTokenDeploySalt",
   });
 
@@ -594,7 +574,6 @@ export const useReadInterchainTokenFactoryLinkedTokenDeploySalt =
 export const useReadInterchainTokenFactoryLinkedTokenId =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "linkedTokenId",
   });
 
@@ -604,7 +583,6 @@ export const useReadInterchainTokenFactoryLinkedTokenId =
 export const useReadInterchainTokenFactoryOwner =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "owner",
   });
 
@@ -614,7 +592,6 @@ export const useReadInterchainTokenFactoryOwner =
 export const useReadInterchainTokenFactoryPendingOwner =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "pendingOwner",
   });
 
@@ -622,10 +599,7 @@ export const useReadInterchainTokenFactoryPendingOwner =
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link interchainTokenFactoryAbi}__
  */
 export const useWriteInterchainTokenFactory =
-  /*#__PURE__*/ createUseWriteContract({
-    abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
-  });
+  /*#__PURE__*/ createUseWriteContract({ abi: interchainTokenFactoryAbi });
 
 /**
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link interchainTokenFactoryAbi}__ and `functionName` set to `"acceptOwnership"`
@@ -633,7 +607,6 @@ export const useWriteInterchainTokenFactory =
 export const useWriteInterchainTokenFactoryAcceptOwnership =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "acceptOwnership",
   });
 
@@ -643,7 +616,6 @@ export const useWriteInterchainTokenFactoryAcceptOwnership =
 export const useWriteInterchainTokenFactoryApproveDeployRemoteInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "approveDeployRemoteInterchainToken",
   });
 
@@ -653,7 +625,6 @@ export const useWriteInterchainTokenFactoryApproveDeployRemoteInterchainToken =
 export const useWriteInterchainTokenFactoryDeployInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployInterchainToken",
   });
 
@@ -663,7 +634,6 @@ export const useWriteInterchainTokenFactoryDeployInterchainToken =
 export const useWriteInterchainTokenFactoryDeployRemoteCanonicalInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployRemoteCanonicalInterchainToken",
   });
 
@@ -673,7 +643,6 @@ export const useWriteInterchainTokenFactoryDeployRemoteCanonicalInterchainToken 
 export const useWriteInterchainTokenFactoryDeployRemoteInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployRemoteInterchainToken",
   });
 
@@ -683,7 +652,6 @@ export const useWriteInterchainTokenFactoryDeployRemoteInterchainToken =
 export const useWriteInterchainTokenFactoryDeployRemoteInterchainTokenWithMinter =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployRemoteInterchainTokenWithMinter",
   });
 
@@ -693,7 +661,6 @@ export const useWriteInterchainTokenFactoryDeployRemoteInterchainTokenWithMinter
 export const useWriteInterchainTokenFactoryLinkToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "linkToken",
   });
 
@@ -703,7 +670,6 @@ export const useWriteInterchainTokenFactoryLinkToken =
 export const useWriteInterchainTokenFactoryMulticall =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "multicall",
   });
 
@@ -713,7 +679,6 @@ export const useWriteInterchainTokenFactoryMulticall =
 export const useWriteInterchainTokenFactoryProposeOwnership =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "proposeOwnership",
   });
 
@@ -723,7 +688,6 @@ export const useWriteInterchainTokenFactoryProposeOwnership =
 export const useWriteInterchainTokenFactoryRegisterCanonicalInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "registerCanonicalInterchainToken",
   });
 
@@ -733,7 +697,6 @@ export const useWriteInterchainTokenFactoryRegisterCanonicalInterchainToken =
 export const useWriteInterchainTokenFactoryRegisterCustomToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "registerCustomToken",
   });
 
@@ -743,7 +706,6 @@ export const useWriteInterchainTokenFactoryRegisterCustomToken =
 export const useWriteInterchainTokenFactoryRevokeDeployRemoteInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "revokeDeployRemoteInterchainToken",
   });
 
@@ -753,7 +715,6 @@ export const useWriteInterchainTokenFactoryRevokeDeployRemoteInterchainToken =
 export const useWriteInterchainTokenFactorySetup =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "setup",
   });
 
@@ -763,7 +724,6 @@ export const useWriteInterchainTokenFactorySetup =
 export const useWriteInterchainTokenFactoryTransferOwnership =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "transferOwnership",
   });
 
@@ -773,7 +733,6 @@ export const useWriteInterchainTokenFactoryTransferOwnership =
 export const useWriteInterchainTokenFactoryUpgrade =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "upgrade",
   });
 
@@ -781,10 +740,7 @@ export const useWriteInterchainTokenFactoryUpgrade =
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link interchainTokenFactoryAbi}__
  */
 export const useSimulateInterchainTokenFactory =
-  /*#__PURE__*/ createUseSimulateContract({
-    abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
-  });
+  /*#__PURE__*/ createUseSimulateContract({ abi: interchainTokenFactoryAbi });
 
 /**
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link interchainTokenFactoryAbi}__ and `functionName` set to `"acceptOwnership"`
@@ -792,7 +748,6 @@ export const useSimulateInterchainTokenFactory =
 export const useSimulateInterchainTokenFactoryAcceptOwnership =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "acceptOwnership",
   });
 
@@ -802,7 +757,6 @@ export const useSimulateInterchainTokenFactoryAcceptOwnership =
 export const useSimulateInterchainTokenFactoryApproveDeployRemoteInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "approveDeployRemoteInterchainToken",
   });
 
@@ -812,7 +766,6 @@ export const useSimulateInterchainTokenFactoryApproveDeployRemoteInterchainToken
 export const useSimulateInterchainTokenFactoryDeployInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployInterchainToken",
   });
 
@@ -822,7 +775,6 @@ export const useSimulateInterchainTokenFactoryDeployInterchainToken =
 export const useSimulateInterchainTokenFactoryDeployRemoteCanonicalInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployRemoteCanonicalInterchainToken",
   });
 
@@ -832,7 +784,6 @@ export const useSimulateInterchainTokenFactoryDeployRemoteCanonicalInterchainTok
 export const useSimulateInterchainTokenFactoryDeployRemoteInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployRemoteInterchainToken",
   });
 
@@ -842,7 +793,6 @@ export const useSimulateInterchainTokenFactoryDeployRemoteInterchainToken =
 export const useSimulateInterchainTokenFactoryDeployRemoteInterchainTokenWithMinter =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "deployRemoteInterchainTokenWithMinter",
   });
 
@@ -852,7 +802,6 @@ export const useSimulateInterchainTokenFactoryDeployRemoteInterchainTokenWithMin
 export const useSimulateInterchainTokenFactoryLinkToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "linkToken",
   });
 
@@ -862,7 +811,6 @@ export const useSimulateInterchainTokenFactoryLinkToken =
 export const useSimulateInterchainTokenFactoryMulticall =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "multicall",
   });
 
@@ -872,7 +820,6 @@ export const useSimulateInterchainTokenFactoryMulticall =
 export const useSimulateInterchainTokenFactoryProposeOwnership =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "proposeOwnership",
   });
 
@@ -882,7 +829,6 @@ export const useSimulateInterchainTokenFactoryProposeOwnership =
 export const useSimulateInterchainTokenFactoryRegisterCanonicalInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "registerCanonicalInterchainToken",
   });
 
@@ -892,7 +838,6 @@ export const useSimulateInterchainTokenFactoryRegisterCanonicalInterchainToken =
 export const useSimulateInterchainTokenFactoryRegisterCustomToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "registerCustomToken",
   });
 
@@ -902,7 +847,6 @@ export const useSimulateInterchainTokenFactoryRegisterCustomToken =
 export const useSimulateInterchainTokenFactoryRevokeDeployRemoteInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "revokeDeployRemoteInterchainToken",
   });
 
@@ -912,7 +856,6 @@ export const useSimulateInterchainTokenFactoryRevokeDeployRemoteInterchainToken 
 export const useSimulateInterchainTokenFactorySetup =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "setup",
   });
 
@@ -922,7 +865,6 @@ export const useSimulateInterchainTokenFactorySetup =
 export const useSimulateInterchainTokenFactoryTransferOwnership =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "transferOwnership",
   });
 
@@ -932,7 +874,6 @@ export const useSimulateInterchainTokenFactoryTransferOwnership =
 export const useSimulateInterchainTokenFactoryUpgrade =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     functionName: "upgrade",
   });
 
@@ -940,10 +881,7 @@ export const useSimulateInterchainTokenFactoryUpgrade =
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link interchainTokenFactoryAbi}__
  */
 export const useWatchInterchainTokenFactoryEvent =
-  /*#__PURE__*/ createUseWatchContractEvent({
-    abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
-  });
+  /*#__PURE__*/ createUseWatchContractEvent({ abi: interchainTokenFactoryAbi });
 
 /**
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link interchainTokenFactoryAbi}__ and `eventName` set to `"DeployRemoteInterchainTokenApproval"`
@@ -951,7 +889,6 @@ export const useWatchInterchainTokenFactoryEvent =
 export const useWatchInterchainTokenFactoryDeployRemoteInterchainTokenApprovalEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     eventName: "DeployRemoteInterchainTokenApproval",
   });
 
@@ -961,7 +898,6 @@ export const useWatchInterchainTokenFactoryDeployRemoteInterchainTokenApprovalEv
 export const useWatchInterchainTokenFactoryOwnershipTransferStartedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     eventName: "OwnershipTransferStarted",
   });
 
@@ -971,7 +907,6 @@ export const useWatchInterchainTokenFactoryOwnershipTransferStartedEvent =
 export const useWatchInterchainTokenFactoryOwnershipTransferredEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     eventName: "OwnershipTransferred",
   });
 
@@ -981,7 +916,6 @@ export const useWatchInterchainTokenFactoryOwnershipTransferredEvent =
 export const useWatchInterchainTokenFactoryRevokedDeployRemoteInterchainTokenApprovalEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     eventName: "RevokedDeployRemoteInterchainTokenApproval",
   });
 
@@ -991,6 +925,5 @@ export const useWatchInterchainTokenFactoryRevokedDeployRemoteInterchainTokenApp
 export const useWatchInterchainTokenFactoryUpgradedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenFactoryAbi,
-    address: interchainTokenFactoryAddress,
     eventName: "Upgraded",
   });

--- a/apps/maestro/src/lib/contracts/InterchainTokenService.hooks.ts
+++ b/apps/maestro/src/lib/contracts/InterchainTokenService.hooks.ts
@@ -1165,14 +1165,6 @@ export const interchainTokenServiceAbi = [
   },
 ] as const;
 
-export const interchainTokenServiceAddress =
-  "0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C" as const;
-
-export const interchainTokenServiceConfig = {
-  address: interchainTokenServiceAddress,
-  abi: interchainTokenServiceAbi,
-} as const;
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // React
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1181,10 +1173,7 @@ export const interchainTokenServiceConfig = {
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link interchainTokenServiceAbi}__
  */
 export const useReadInterchainTokenService =
-  /*#__PURE__*/ createUseReadContract({
-    abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
-  });
+  /*#__PURE__*/ createUseReadContract({ abi: interchainTokenServiceAbi });
 
 /**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link interchainTokenServiceAbi}__ and `functionName` set to `"chainName"`
@@ -1192,7 +1181,6 @@ export const useReadInterchainTokenService =
 export const useReadInterchainTokenServiceChainName =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "chainName",
   });
 
@@ -1202,7 +1190,6 @@ export const useReadInterchainTokenServiceChainName =
 export const useReadInterchainTokenServiceChainNameHash =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "chainNameHash",
   });
 
@@ -1212,7 +1199,6 @@ export const useReadInterchainTokenServiceChainNameHash =
 export const useReadInterchainTokenServiceContractCallValue =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "contractCallValue",
   });
 
@@ -1222,7 +1208,6 @@ export const useReadInterchainTokenServiceContractCallValue =
 export const useReadInterchainTokenServiceContractId =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "contractId",
   });
 
@@ -1232,7 +1217,6 @@ export const useReadInterchainTokenServiceContractId =
 export const useReadInterchainTokenServiceDeployedTokenManager =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "deployedTokenManager",
   });
 
@@ -1242,7 +1226,6 @@ export const useReadInterchainTokenServiceDeployedTokenManager =
 export const useReadInterchainTokenServiceGasService =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "gasService",
   });
 
@@ -1252,7 +1235,6 @@ export const useReadInterchainTokenServiceGasService =
 export const useReadInterchainTokenServiceGateway =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "gateway",
   });
 
@@ -1262,7 +1244,6 @@ export const useReadInterchainTokenServiceGateway =
 export const useReadInterchainTokenServiceGatewayCaller =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "gatewayCaller",
   });
 
@@ -1272,7 +1253,6 @@ export const useReadInterchainTokenServiceGatewayCaller =
 export const useReadInterchainTokenServiceGetExpressExecutor =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "getExpressExecutor",
   });
 
@@ -1282,7 +1262,6 @@ export const useReadInterchainTokenServiceGetExpressExecutor =
 export const useReadInterchainTokenServiceHasRole =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "hasRole",
   });
 
@@ -1292,7 +1271,6 @@ export const useReadInterchainTokenServiceHasRole =
 export const useReadInterchainTokenServiceImplementation =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "implementation",
   });
 
@@ -1302,7 +1280,6 @@ export const useReadInterchainTokenServiceImplementation =
 export const useReadInterchainTokenServiceInterchainTokenAddress =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "interchainTokenAddress",
   });
 
@@ -1312,7 +1289,6 @@ export const useReadInterchainTokenServiceInterchainTokenAddress =
 export const useReadInterchainTokenServiceInterchainTokenDeployer =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "interchainTokenDeployer",
   });
 
@@ -1322,7 +1298,6 @@ export const useReadInterchainTokenServiceInterchainTokenDeployer =
 export const useReadInterchainTokenServiceInterchainTokenFactory =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "interchainTokenFactory",
   });
 
@@ -1332,7 +1307,6 @@ export const useReadInterchainTokenServiceInterchainTokenFactory =
 export const useReadInterchainTokenServiceInterchainTokenId =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "interchainTokenId",
   });
 
@@ -1342,7 +1316,6 @@ export const useReadInterchainTokenServiceInterchainTokenId =
 export const useReadInterchainTokenServiceIsOperator =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "isOperator",
   });
 
@@ -1352,7 +1325,6 @@ export const useReadInterchainTokenServiceIsOperator =
 export const useReadInterchainTokenServiceIsTrustedAddress =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "isTrustedAddress",
   });
 
@@ -1362,7 +1334,6 @@ export const useReadInterchainTokenServiceIsTrustedAddress =
 export const useReadInterchainTokenServiceOwner =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "owner",
   });
 
@@ -1372,7 +1343,6 @@ export const useReadInterchainTokenServiceOwner =
 export const useReadInterchainTokenServicePaused =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "paused",
   });
 
@@ -1382,7 +1352,6 @@ export const useReadInterchainTokenServicePaused =
 export const useReadInterchainTokenServicePendingOwner =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "pendingOwner",
   });
 
@@ -1392,7 +1361,6 @@ export const useReadInterchainTokenServicePendingOwner =
 export const useReadInterchainTokenServiceRegisteredTokenAddress =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "registeredTokenAddress",
   });
 
@@ -1402,7 +1370,6 @@ export const useReadInterchainTokenServiceRegisteredTokenAddress =
 export const useReadInterchainTokenServiceTokenHandler =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "tokenHandler",
   });
 
@@ -1412,7 +1379,6 @@ export const useReadInterchainTokenServiceTokenHandler =
 export const useReadInterchainTokenServiceTokenManager =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "tokenManager",
   });
 
@@ -1422,7 +1388,6 @@ export const useReadInterchainTokenServiceTokenManager =
 export const useReadInterchainTokenServiceTokenManagerAddress =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "tokenManagerAddress",
   });
 
@@ -1432,7 +1397,6 @@ export const useReadInterchainTokenServiceTokenManagerAddress =
 export const useReadInterchainTokenServiceTokenManagerDeployer =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "tokenManagerDeployer",
   });
 
@@ -1442,7 +1406,6 @@ export const useReadInterchainTokenServiceTokenManagerDeployer =
 export const useReadInterchainTokenServiceTokenManagerImplementation =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "tokenManagerImplementation",
   });
 
@@ -1452,7 +1415,6 @@ export const useReadInterchainTokenServiceTokenManagerImplementation =
 export const useReadInterchainTokenServiceTrustedAddress =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "trustedAddress",
   });
 
@@ -1462,7 +1424,6 @@ export const useReadInterchainTokenServiceTrustedAddress =
 export const useReadInterchainTokenServiceTrustedAddressHash =
   /*#__PURE__*/ createUseReadContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "trustedAddressHash",
   });
 
@@ -1470,10 +1431,7 @@ export const useReadInterchainTokenServiceTrustedAddressHash =
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link interchainTokenServiceAbi}__
  */
 export const useWriteInterchainTokenService =
-  /*#__PURE__*/ createUseWriteContract({
-    abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
-  });
+  /*#__PURE__*/ createUseWriteContract({ abi: interchainTokenServiceAbi });
 
 /**
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link interchainTokenServiceAbi}__ and `functionName` set to `"acceptOperatorship"`
@@ -1481,7 +1439,6 @@ export const useWriteInterchainTokenService =
 export const useWriteInterchainTokenServiceAcceptOperatorship =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "acceptOperatorship",
   });
 
@@ -1491,7 +1448,6 @@ export const useWriteInterchainTokenServiceAcceptOperatorship =
 export const useWriteInterchainTokenServiceAcceptOwnership =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "acceptOwnership",
   });
 
@@ -1501,7 +1457,6 @@ export const useWriteInterchainTokenServiceAcceptOwnership =
 export const useWriteInterchainTokenServiceDeployInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "deployInterchainToken",
   });
 
@@ -1511,7 +1466,6 @@ export const useWriteInterchainTokenServiceDeployInterchainToken =
 export const useWriteInterchainTokenServiceExecute =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "execute",
   });
 
@@ -1521,7 +1475,6 @@ export const useWriteInterchainTokenServiceExecute =
 export const useWriteInterchainTokenServiceExpressExecute =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "expressExecute",
   });
 
@@ -1531,7 +1484,6 @@ export const useWriteInterchainTokenServiceExpressExecute =
 export const useWriteInterchainTokenServiceInterchainTransfer =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "interchainTransfer",
   });
 
@@ -1541,7 +1493,6 @@ export const useWriteInterchainTokenServiceInterchainTransfer =
 export const useWriteInterchainTokenServiceLinkToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "linkToken",
   });
 
@@ -1551,7 +1502,6 @@ export const useWriteInterchainTokenServiceLinkToken =
 export const useWriteInterchainTokenServiceMigrateInterchainToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "migrateInterchainToken",
   });
 
@@ -1561,7 +1511,6 @@ export const useWriteInterchainTokenServiceMigrateInterchainToken =
 export const useWriteInterchainTokenServiceMulticall =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "multicall",
   });
 
@@ -1571,7 +1520,6 @@ export const useWriteInterchainTokenServiceMulticall =
 export const useWriteInterchainTokenServiceProposeOperatorship =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "proposeOperatorship",
   });
 
@@ -1581,7 +1529,6 @@ export const useWriteInterchainTokenServiceProposeOperatorship =
 export const useWriteInterchainTokenServiceProposeOwnership =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "proposeOwnership",
   });
 
@@ -1591,7 +1538,6 @@ export const useWriteInterchainTokenServiceProposeOwnership =
 export const useWriteInterchainTokenServiceRegisterCustomToken =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "registerCustomToken",
   });
 
@@ -1601,7 +1547,6 @@ export const useWriteInterchainTokenServiceRegisterCustomToken =
 export const useWriteInterchainTokenServiceRegisterTokenMetadata =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "registerTokenMetadata",
   });
 
@@ -1611,7 +1556,6 @@ export const useWriteInterchainTokenServiceRegisterTokenMetadata =
 export const useWriteInterchainTokenServiceRemoveTrustedAddress =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "removeTrustedAddress",
   });
 
@@ -1621,7 +1565,6 @@ export const useWriteInterchainTokenServiceRemoveTrustedAddress =
 export const useWriteInterchainTokenServiceSetFlowLimits =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setFlowLimits",
   });
 
@@ -1631,7 +1574,6 @@ export const useWriteInterchainTokenServiceSetFlowLimits =
 export const useWriteInterchainTokenServiceSetPauseStatus =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setPauseStatus",
   });
 
@@ -1641,7 +1583,6 @@ export const useWriteInterchainTokenServiceSetPauseStatus =
 export const useWriteInterchainTokenServiceSetTrustedAddress =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setTrustedAddress",
   });
 
@@ -1651,7 +1592,6 @@ export const useWriteInterchainTokenServiceSetTrustedAddress =
 export const useWriteInterchainTokenServiceSetup =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setup",
   });
 
@@ -1661,7 +1601,6 @@ export const useWriteInterchainTokenServiceSetup =
 export const useWriteInterchainTokenServiceTransferOperatorship =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "transferOperatorship",
   });
 
@@ -1671,7 +1610,6 @@ export const useWriteInterchainTokenServiceTransferOperatorship =
 export const useWriteInterchainTokenServiceTransferOwnership =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "transferOwnership",
   });
 
@@ -1681,7 +1619,6 @@ export const useWriteInterchainTokenServiceTransferOwnership =
 export const useWriteInterchainTokenServiceTransmitInterchainTransfer =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "transmitInterchainTransfer",
   });
 
@@ -1691,7 +1628,6 @@ export const useWriteInterchainTokenServiceTransmitInterchainTransfer =
 export const useWriteInterchainTokenServiceUpgrade =
   /*#__PURE__*/ createUseWriteContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "upgrade",
   });
 
@@ -1699,10 +1635,7 @@ export const useWriteInterchainTokenServiceUpgrade =
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link interchainTokenServiceAbi}__
  */
 export const useSimulateInterchainTokenService =
-  /*#__PURE__*/ createUseSimulateContract({
-    abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
-  });
+  /*#__PURE__*/ createUseSimulateContract({ abi: interchainTokenServiceAbi });
 
 /**
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link interchainTokenServiceAbi}__ and `functionName` set to `"acceptOperatorship"`
@@ -1710,7 +1643,6 @@ export const useSimulateInterchainTokenService =
 export const useSimulateInterchainTokenServiceAcceptOperatorship =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "acceptOperatorship",
   });
 
@@ -1720,7 +1652,6 @@ export const useSimulateInterchainTokenServiceAcceptOperatorship =
 export const useSimulateInterchainTokenServiceAcceptOwnership =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "acceptOwnership",
   });
 
@@ -1730,7 +1661,6 @@ export const useSimulateInterchainTokenServiceAcceptOwnership =
 export const useSimulateInterchainTokenServiceDeployInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "deployInterchainToken",
   });
 
@@ -1740,7 +1670,6 @@ export const useSimulateInterchainTokenServiceDeployInterchainToken =
 export const useSimulateInterchainTokenServiceExecute =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "execute",
   });
 
@@ -1750,7 +1679,6 @@ export const useSimulateInterchainTokenServiceExecute =
 export const useSimulateInterchainTokenServiceExpressExecute =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "expressExecute",
   });
 
@@ -1760,7 +1688,6 @@ export const useSimulateInterchainTokenServiceExpressExecute =
 export const useSimulateInterchainTokenServiceInterchainTransfer =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "interchainTransfer",
   });
 
@@ -1770,7 +1697,6 @@ export const useSimulateInterchainTokenServiceInterchainTransfer =
 export const useSimulateInterchainTokenServiceLinkToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "linkToken",
   });
 
@@ -1780,7 +1706,6 @@ export const useSimulateInterchainTokenServiceLinkToken =
 export const useSimulateInterchainTokenServiceMigrateInterchainToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "migrateInterchainToken",
   });
 
@@ -1790,7 +1715,6 @@ export const useSimulateInterchainTokenServiceMigrateInterchainToken =
 export const useSimulateInterchainTokenServiceMulticall =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "multicall",
   });
 
@@ -1800,7 +1724,6 @@ export const useSimulateInterchainTokenServiceMulticall =
 export const useSimulateInterchainTokenServiceProposeOperatorship =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "proposeOperatorship",
   });
 
@@ -1810,7 +1733,6 @@ export const useSimulateInterchainTokenServiceProposeOperatorship =
 export const useSimulateInterchainTokenServiceProposeOwnership =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "proposeOwnership",
   });
 
@@ -1820,7 +1742,6 @@ export const useSimulateInterchainTokenServiceProposeOwnership =
 export const useSimulateInterchainTokenServiceRegisterCustomToken =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "registerCustomToken",
   });
 
@@ -1830,7 +1751,6 @@ export const useSimulateInterchainTokenServiceRegisterCustomToken =
 export const useSimulateInterchainTokenServiceRegisterTokenMetadata =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "registerTokenMetadata",
   });
 
@@ -1840,7 +1760,6 @@ export const useSimulateInterchainTokenServiceRegisterTokenMetadata =
 export const useSimulateInterchainTokenServiceRemoveTrustedAddress =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "removeTrustedAddress",
   });
 
@@ -1850,7 +1769,6 @@ export const useSimulateInterchainTokenServiceRemoveTrustedAddress =
 export const useSimulateInterchainTokenServiceSetFlowLimits =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setFlowLimits",
   });
 
@@ -1860,7 +1778,6 @@ export const useSimulateInterchainTokenServiceSetFlowLimits =
 export const useSimulateInterchainTokenServiceSetPauseStatus =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setPauseStatus",
   });
 
@@ -1870,7 +1787,6 @@ export const useSimulateInterchainTokenServiceSetPauseStatus =
 export const useSimulateInterchainTokenServiceSetTrustedAddress =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setTrustedAddress",
   });
 
@@ -1880,7 +1796,6 @@ export const useSimulateInterchainTokenServiceSetTrustedAddress =
 export const useSimulateInterchainTokenServiceSetup =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "setup",
   });
 
@@ -1890,7 +1805,6 @@ export const useSimulateInterchainTokenServiceSetup =
 export const useSimulateInterchainTokenServiceTransferOperatorship =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "transferOperatorship",
   });
 
@@ -1900,7 +1814,6 @@ export const useSimulateInterchainTokenServiceTransferOperatorship =
 export const useSimulateInterchainTokenServiceTransferOwnership =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "transferOwnership",
   });
 
@@ -1910,7 +1823,6 @@ export const useSimulateInterchainTokenServiceTransferOwnership =
 export const useSimulateInterchainTokenServiceTransmitInterchainTransfer =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "transmitInterchainTransfer",
   });
 
@@ -1920,7 +1832,6 @@ export const useSimulateInterchainTokenServiceTransmitInterchainTransfer =
 export const useSimulateInterchainTokenServiceUpgrade =
   /*#__PURE__*/ createUseSimulateContract({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     functionName: "upgrade",
   });
 
@@ -1928,10 +1839,7 @@ export const useSimulateInterchainTokenServiceUpgrade =
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link interchainTokenServiceAbi}__
  */
 export const useWatchInterchainTokenServiceEvent =
-  /*#__PURE__*/ createUseWatchContractEvent({
-    abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
-  });
+  /*#__PURE__*/ createUseWatchContractEvent({ abi: interchainTokenServiceAbi });
 
 /**
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link interchainTokenServiceAbi}__ and `eventName` set to `"ExpressExecuted"`
@@ -1939,7 +1847,6 @@ export const useWatchInterchainTokenServiceEvent =
 export const useWatchInterchainTokenServiceExpressExecutedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "ExpressExecuted",
   });
 
@@ -1949,7 +1856,6 @@ export const useWatchInterchainTokenServiceExpressExecutedEvent =
 export const useWatchInterchainTokenServiceExpressExecutionFulfilledEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "ExpressExecutionFulfilled",
   });
 
@@ -1959,7 +1865,6 @@ export const useWatchInterchainTokenServiceExpressExecutionFulfilledEvent =
 export const useWatchInterchainTokenServiceInterchainTokenDeployedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "InterchainTokenDeployed",
   });
 
@@ -1969,7 +1874,6 @@ export const useWatchInterchainTokenServiceInterchainTokenDeployedEvent =
 export const useWatchInterchainTokenServiceInterchainTokenDeploymentStartedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "InterchainTokenDeploymentStarted",
   });
 
@@ -1979,7 +1883,6 @@ export const useWatchInterchainTokenServiceInterchainTokenDeploymentStartedEvent
 export const useWatchInterchainTokenServiceInterchainTokenIdClaimedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "InterchainTokenIdClaimed",
   });
 
@@ -1989,7 +1892,6 @@ export const useWatchInterchainTokenServiceInterchainTokenIdClaimedEvent =
 export const useWatchInterchainTokenServiceInterchainTransferEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "InterchainTransfer",
   });
 
@@ -1999,7 +1901,6 @@ export const useWatchInterchainTokenServiceInterchainTransferEvent =
 export const useWatchInterchainTokenServiceInterchainTransferReceivedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "InterchainTransferReceived",
   });
 
@@ -2009,7 +1910,6 @@ export const useWatchInterchainTokenServiceInterchainTransferReceivedEvent =
 export const useWatchInterchainTokenServiceLinkTokenStartedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "LinkTokenStarted",
   });
 
@@ -2019,7 +1919,6 @@ export const useWatchInterchainTokenServiceLinkTokenStartedEvent =
 export const useWatchInterchainTokenServiceOwnershipTransferStartedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "OwnershipTransferStarted",
   });
 
@@ -2029,7 +1928,6 @@ export const useWatchInterchainTokenServiceOwnershipTransferStartedEvent =
 export const useWatchInterchainTokenServiceOwnershipTransferredEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "OwnershipTransferred",
   });
 
@@ -2039,7 +1937,6 @@ export const useWatchInterchainTokenServiceOwnershipTransferredEvent =
 export const useWatchInterchainTokenServicePausedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "Paused",
   });
 
@@ -2049,7 +1946,6 @@ export const useWatchInterchainTokenServicePausedEvent =
 export const useWatchInterchainTokenServiceRolesAddedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "RolesAdded",
   });
 
@@ -2059,7 +1955,6 @@ export const useWatchInterchainTokenServiceRolesAddedEvent =
 export const useWatchInterchainTokenServiceRolesProposedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "RolesProposed",
   });
 
@@ -2069,7 +1964,6 @@ export const useWatchInterchainTokenServiceRolesProposedEvent =
 export const useWatchInterchainTokenServiceRolesRemovedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "RolesRemoved",
   });
 
@@ -2079,7 +1973,6 @@ export const useWatchInterchainTokenServiceRolesRemovedEvent =
 export const useWatchInterchainTokenServiceTokenManagerDeployedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "TokenManagerDeployed",
   });
 
@@ -2089,7 +1982,6 @@ export const useWatchInterchainTokenServiceTokenManagerDeployedEvent =
 export const useWatchInterchainTokenServiceTokenMetadataRegisteredEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "TokenMetadataRegistered",
   });
 
@@ -2099,7 +1991,6 @@ export const useWatchInterchainTokenServiceTokenMetadataRegisteredEvent =
 export const useWatchInterchainTokenServiceTrustedAddressRemovedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "TrustedAddressRemoved",
   });
 
@@ -2109,7 +2000,6 @@ export const useWatchInterchainTokenServiceTrustedAddressRemovedEvent =
 export const useWatchInterchainTokenServiceTrustedAddressSetEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "TrustedAddressSet",
   });
 
@@ -2119,7 +2009,6 @@ export const useWatchInterchainTokenServiceTrustedAddressSetEvent =
 export const useWatchInterchainTokenServiceUnpausedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "Unpaused",
   });
 
@@ -2129,6 +2018,5 @@ export const useWatchInterchainTokenServiceUnpausedEvent =
 export const useWatchInterchainTokenServiceUpgradedEvent =
   /*#__PURE__*/ createUseWatchContractEvent({
     abi: interchainTokenServiceAbi,
-    address: interchainTokenServiceAddress,
     eventName: "Upgraded",
   });

--- a/apps/maestro/src/lib/contracts/index.ts
+++ b/apps/maestro/src/lib/contracts/index.ts
@@ -18,12 +18,12 @@ export const contracts = [
   {
     name: INTERCHAIN_TOKEN_FACTORY_ABI.contractName,
     abi: INTERCHAIN_TOKEN_FACTORY_ABI.abi,
-    address: "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66" as `0x${string}`, // read from .env.local (NEXT_PUBLIC_INTERCHAIN_TOKEN_FACTORY_ADDRESS)
+    address: undefined, // you can set this as NEXT_PUBLIC_INTERCHAIN_TOKEN_FACTORY_ADDRESS in .env.local for fixed contract addresses
   },
   {
     name: INTERCHAIN_TOKEN_SERVICE_ABI.contractName,
     abi: INTERCHAIN_TOKEN_SERVICE_ABI.abi,
-    address: "0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C" as `0x${string}`, // read from .env.local (NEXT_PUBLIC_INTERCHAIN_TOKEN_SERVICE_ADDRESS)
+    address: undefined, // you can set this as NEXT_PUBLIC_INTERCHAIN_TOKEN_SERVICE_ADDRESS in .env.local for fixed contract addresses
   },
   {
     name: TOKEN_MANAGER_ABI.contractName,


### PR DESCRIPTION
Switch to `deployRemoteInterchainTokenWithMinter` and disable default remote minter setting.

This change addresses complexities with minter behavior across different chain types and enhances security by not setting a default minter on remote token deployments. It also updates the portal to use the latest ITS factory method (`deployRemoteInterchainTokenWithMinter`), which replaces deprecated methods that will be removed in an upcoming ITS release.