### PR TITLE
ITS-69 Add Hedera specific rules in token creation

### DIFF
--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
@@ -270,29 +270,26 @@ const TokenDetails: FC = () => {
         )}
         {isMintable && (
           <FormControl>
-            <Label>
-              <Label.Text
-                id="minter-label"
-                className="inline-flex items-center gap-1"
-              >
-                Token Minter
-                <Tooltip
-                  $position="right"
-                  $variant="info"
-                  tip="Choose a secure minter address, e.g. governance, multisig etc. This address will be able to mint the token on any chain."
+            <div className="flex items-center justify-between">
+              <Label>
+                <Label.Text
+                  id="minter-label"
+                  className="inline-flex items-center gap-1"
                 >
-                  <HelpCircleIcon className="mr-1 h-[1em] text-info" />
-                </Tooltip>
-              </Label.Text>
-              <Label.AltText>
-                <button
-                  type="button"
-                  onClick={actions.setCurrentAddressAsMinter}
-                >
-                  Use current address
-                </button>
-              </Label.AltText>
-            </Label>
+                  Token Minter
+                  <Tooltip
+                    $position="right"
+                    $variant="info"
+                    tip="Choose a secure minter address, e.g. governance, multisig etc. This address will be able to mint the token on any chain."
+                  >
+                    <HelpCircleIcon className="mr-1 h-[1em] text-info" />
+                  </Tooltip>
+                </Label.Text>
+              </Label>
+              <button type="button" onClick={actions.setCurrentAddressAsMinter}>
+                Use current address
+              </button>
+            </div>
             <ModalFormInput
               id="minter"
               placeholder="Enter a secure minter address"

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
@@ -188,6 +188,8 @@ const TokenDetails: FC = () => {
   };
 
   const { errors } = state.tokenDetailsForm.formState;
+  const showMinterError =
+    formState.dirtyFields?.minter || formState.isSubmitted;
 
   return (
     <>
@@ -299,7 +301,8 @@ const TokenDetails: FC = () => {
               aria-labelledby="minter-label"
               {...register("minter")}
             />
-            {Maybe.of(minterErrorMessage).mapOrNull(ValidationError)}
+            {showMinterError &&
+              Maybe.of(minterErrorMessage).mapOrNull(ValidationError)}
           </FormControl>
         )}
         {!isHedera && (
@@ -352,10 +355,7 @@ const TokenDetails: FC = () => {
         <Dialog.CloseAction onClick={actions.reset}>
           Cancel & exit
         </Dialog.CloseAction>
-        <NextButton
-          disabled={!isFormValid}
-          onClick={() => formSubmitRef.current?.click()}
-        >
+        <NextButton onClick={() => formSubmitRef.current?.click()}>
           <p className="text-indigo-600">Register & Deploy</p>
         </NextButton>
       </Dialog.Actions>

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
@@ -131,8 +131,7 @@ const TokenDetails: FC = () => {
         });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId]);
+  }, [chainId, isMintable, supply, state.tokenDetailsForm]);
 
   const minterErrorMessage = useMemo<FieldError | undefined>(() => {
     if (!isMintable) {

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/token-details/TokenDetails.tsx
@@ -104,7 +104,7 @@ const validateMinterAddress = (minter: string | undefined, chainId: number) => {
 const TokenDetails: FC = () => {
   const { state, actions } = useInterchainTokenDeploymentStateContainer();
   const chainId = useChainId();
-  const chainRules = useMemo(() => CHAIN_RULES[chainId], [chainId]);
+  const chainRules = CHAIN_RULES[chainId];
   const isInitialSupplyHidden =
     chainRules?.hiddenFields?.includes("initialSupply") === true;
   const hasIsMintableRule = chainRules?.isMintable !== undefined;


### PR DESCRIPTION
This PR implements some Hedera specific rules on new Interchain Token creation:
- token must be mintable
- token initial supply must be 0

The affected form fields are removed from the UI and their value is set programatically.

It also adds an informational note on the token creation modal. Some UI fixes also applied.

<img width="458" height="765" alt="Screenshot 2025-09-18 at 20 37 46" src="https://github.com/user-attachments/assets/f554e16e-1961-4239-84a3-0fce657e7d4a" />