### PR TITLE
ITS-71 Hedera interchain token transfers

### DIFF
--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
@@ -109,14 +109,15 @@ export function useSendInterchainTokenState(props: {
 
   const [, { addTransaction }] = useTransactionsContainer();
 
+  const rawWalletBalance = useBalance();
   const balance = scaleGasValue(
     props.sourceChain.chain_id,
-    useBalance()?.value ?? 0n
+    rawWalletBalance?.value ?? 0n
   );
 
   const nativeTokenSymbol = getNativeToken(props.sourceChain.id.toLowerCase());
 
-  let { data: gas } = useEstimateGasFeeQuery({
+  const rawEstimateGasFeeData = useEstimateGasFeeQuery({
     sourceChainId: props.sourceChain.id,
     destinationChainId: selectedToChain?.id,
     sourceChainTokenSymbol: nativeTokenSymbol,
@@ -125,7 +126,10 @@ export function useSendInterchainTokenState(props: {
     gasMultiplier: "auto",
   });
 
-  gas = scaleGasValue(props.sourceChain.chain_id, gas);
+  const gas = scaleGasValue(
+    props.sourceChain.chain_id,
+    rawEstimateGasFeeData.data
+  );
 
   const hasInsufficientGasBalance = useMemo(() => {
     if (!balance || !gas) {

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
@@ -22,6 +22,9 @@ import { useTransactionsContainer } from "../Transactions";
 import { useInterchainTokenServiceTransferMutation } from "./hooks/useInterchainTokenServiceTransferMutation";
 import { useInterchainTransferMutation } from "./hooks/useInterchainTransferMutation";
 
+// Chains that should force using Interchain Token Service path
+const CHAINS_REQUIRING_TOKEN_SERVICE = [HEDERA_CHAIN_ID];
+
 export function useSendInterchainTokenState(props: {
   tokenAddress: string;
   originTokenAddress?: `0x${string}`;
@@ -65,7 +68,8 @@ export function useSendInterchainTokenState(props: {
   );
 
   const shouldUseTokenService =
-    props.sourceChain.chain_id === HEDERA_CHAIN_ID || isApprovalRequired;
+    CHAINS_REQUIRING_TOKEN_SERVICE.includes(props.sourceChain.chain_id) ||
+    isApprovalRequired;
 
   const [isModalOpen, setIsModalOpen] = useState(props.isModalOpen ?? false);
   const [toChainId, selectToChain] = useState(5);

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
@@ -1,6 +1,7 @@
 import { Maybe } from "@axelarjs/utils";
 import { useMemo, useState } from "react";
 
+import { HEDERA_CHAIN_ID } from "~/config/chains";
 import {
   NEXT_PUBLIC_INTERCHAIN_DEPLOYMENT_EXECUTE_DATA,
   NEXT_PUBLIC_INTERCHAIN_TRANSFER_GAS_LIMIT,
@@ -62,6 +63,9 @@ export function useSendInterchainTokenState(props: {
       props.sourceChain.chain_type,
     ]
   );
+
+  const shouldUseTokenService =
+    props.sourceChain.chain_id === HEDERA_CHAIN_ID || isApprovalRequired;
 
   const [isModalOpen, setIsModalOpen] = useState(props.isModalOpen ?? false);
   const [toChainId, selectToChain] = useState(5);
@@ -160,7 +164,7 @@ export function useSendInterchainTokenState(props: {
 
   const { sendTokenAsync, isSending, txState } = useMemo(
     () =>
-      isApprovalRequired
+      shouldUseTokenService
         ? {
             sendTokenAsync: tokenServiceSendTokenAsync,
             isSending: isTokenServiceTransfering,
@@ -172,7 +176,7 @@ export function useSendInterchainTokenState(props: {
             txState: interchainTransferTxState,
           },
     [
-      isApprovalRequired,
+      shouldUseTokenService,
       tokenServiceSendTokenAsync,
       isTokenServiceTransfering,
       tokenServiceTxState,

--- a/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
+++ b/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
@@ -23,6 +23,7 @@ import {
 } from "~/lib/contracts/InterchainTokenService.hooks";
 import { useAccount, useChainId, useTransactionState } from "~/lib/hooks";
 import { logger } from "~/lib/logger";
+import { scaleGasValue } from "~/lib/utils/gas";
 import { encodeStellarAddressAsBytes } from "~/lib/utils/stellar";
 
 // Chains that should use the Token Manager as the spender for approvals
@@ -115,7 +116,7 @@ export function useInterchainTokenServiceTransferMutation(
               : ((destinationAddress as `0x${string}`) ?? address),
             amount: approvedAmountRef.current,
             metadata: "0x",
-            gasValue: config.gas ?? 0n,
+            gasValue: scaleGasValue(chainId, config.gas ?? 0n),
           }),
           value: config.gas,
         });

--- a/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
+++ b/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
@@ -23,7 +23,6 @@ import {
 } from "~/lib/contracts/InterchainTokenService.hooks";
 import { useAccount, useChainId, useTransactionState } from "~/lib/hooks";
 import { logger } from "~/lib/logger";
-import { scaleGasValue } from "~/lib/utils/gas";
 import { encodeStellarAddressAsBytes } from "~/lib/utils/stellar";
 
 // Chains that should use the Token Manager as the spender for approvals
@@ -116,7 +115,7 @@ export function useInterchainTokenServiceTransferMutation(
               : ((destinationAddress as `0x${string}`) ?? address),
             amount: approvedAmountRef.current,
             metadata: "0x",
-            gasValue: scaleGasValue(chainId, config.gas ?? 0n),
+            gasValue: config.gas ?? 0n,
           }),
           value: config.gas,
         });

--- a/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
+++ b/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
@@ -69,7 +69,7 @@ export function useInterchainTokenServiceTransferMutation(
     });
 
   const approvalSpender = shouldUseTokenManagerAsSpender
-    ? ((tokenManagerAddress as `0x${string}`) ?? "0x")
+    ? (tokenManagerAddress ?? "0x")
     : NEXT_PUBLIC_INTERCHAIN_TOKEN_SERVICE_ADDRESS;
 
   const { data: tokenAllowance } = useWatchInterchainTokenAllowance(


### PR DESCRIPTION
Implements Interchain Transfer for Hedera, using ITS and Token Manager as spender.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Hedera-specific ITS transfer path using Token Manager as spender and normalize gas/balance units for accurate checks.
> 
> - **Interchain transfer behavior (Hedera)**
>   - Force Interchain Token Service path on `HEDERA` via `CHAINS_REQUIRING_TOKEN_SERVICE` and `shouldUseTokenService`.
>   - Use Token Manager as approval spender on `HEDERA` via `CHAINS_USING_TOKEN_MANAGER_AS_SPENDER`; fetch with `tokenManagerAddress` and apply to allowance watch and approve calls.
> - **Gas/balance handling**
>   - Normalize gas and balance using `scaleGasValue` and compare directly to detect insufficient gas.
> - **State/Hook updates**
>   - Route send flow based on `shouldUseTokenService`.
>   - Pass scaled `gas` through to mutations; minor refactors to support new logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d01a638302313eba84aff1e6ad3f76216c63f7ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->