### PR TITLE
ITS-98 Fix gas usage in interchain token transfer

### DIFF
--- a/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
+++ b/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
@@ -270,8 +270,15 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
         status: "idle",
       });
 
-      toast.error(`Transaction failed: ${error.cause?.shortMessage}`);
-      logger.error("Failed to register remote tokens", error.cause);
+      toast.error(
+        `Failed to register remote tokens: ${
+          error?.cause?.shortMessage ??
+          error?.shortMessage ??
+          error?.message ??
+          "Unknown error"
+        }`
+      );
+      logger.error("Failed to register remote tokens", error);
     }
   }, [registerTokensAsync, setTxState, props.originChainId]);
 

--- a/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
+++ b/apps/maestro/src/features/SendInterchainToken/SendInterchainToken.state.ts
@@ -24,6 +24,9 @@ import { useInterchainTransferMutation } from "./hooks/useInterchainTransferMuta
 
 // Chains that should force using Interchain Token Service path
 const CHAINS_REQUIRING_TOKEN_SERVICE = [HEDERA_CHAIN_ID];
+const CHAINS_GAS_FEE_DECIMALS = {
+  [HEDERA_CHAIN_ID]: 18,
+};
 
 export function useSendInterchainTokenState(props: {
   tokenAddress: string;
@@ -199,7 +202,9 @@ export function useSendInterchainTokenState(props: {
       eligibleTargetChains,
       tokenSymbol,
       gasFee: Maybe.of(gas).mapOrUndefined((gasValue) => {
-        const decimals = props.sourceChain.native_token.decimals;
+        const decimals =
+          CHAINS_GAS_FEE_DECIMALS[props.sourceChain.chain_id] ||
+          props.sourceChain.native_token.decimals;
         return toNumericString(gasValue, decimals);
       }),
       nativeTokenSymbol,

--- a/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
+++ b/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
@@ -168,6 +168,7 @@ export function useInterchainTokenServiceTransferMutation(
       config.tokenId,
       interchainTransferAsync,
       setTxState,
+      shouldScaleGas,
     ]
   );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix gas calculation/scaling and balance checks for interchain transfers (incl. Hedera) and enhance error messaging/logging.
> 
> - **Interchain transfer gas and balances**:
>   - Use `useEstimateGasFeeQuery().data` and compare `gas` against `balance.value` in `SendInterchainToken.state`.
>   - Add Hedera-specific overrides: `CHAINS_GAS_FEE_DECIMALS` for gas fee formatting and conditional gas scaling via `CHAINS_SCALED_GAS` with `scaleGasValue` in `useInterchainTokenServiceTransferMutation`.
>   - Remove unnecessary `scaleGasValue` usage in state and rely on raw `useBalance()`/query outputs.
>   - Set transaction `value` to `config.gas ?? 0n`.
>   - Add readiness guard with toast on missing `decimals/address/gas/approvalSpender` before initiating transfer.
> - **Error handling**:
>   - Improve failure toast and logging in `RegisterRemoteTokens.tsx` with broader error fallbacks and full error logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7926256b1e7ca80c70839cea4e75fe4cb70abeeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->