### PR TITLE
Fixes wrong remote deployment filter

### DIFF
--- a/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -25,7 +25,7 @@ import { RegisterCanonicalTokenResult } from "~/features/suiHooks/useRegisterCan
 import { useTransactionsContainer } from "~/features/Transactions";
 import { useBalance, useChainId } from "~/lib/hooks";
 import { handleTransactionResult } from "~/lib/transactions/handlers";
-import { filterEligibleChains } from "~/lib/utils/chains";
+import { filterEligibleChainsForRemoteDeployment } from "~/lib/utils/chains";
 import { getNativeToken } from "~/lib/utils/getNativeToken";
 import ChainPicker from "~/ui/compounds/ChainPicker";
 import { NextButton, TokenNameAlert } from "~/ui/compounds/MultiStepForm";
@@ -258,7 +258,7 @@ export const Step3: FC = () => {
     ]
   );
 
-  const eligibleChains = filterEligibleChains(state.chains, chainId);
+  const eligibleChains = filterEligibleChainsForRemoteDeployment(state.chains, chainId);
 
   const formSubmitRef = useRef<ComponentRef<"button">>(null);
 

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -4,7 +4,7 @@ import { ComponentRef, useMemo, useRef, type FC } from "react";
 import { parseUnits } from "viem";
 
 import { useBalance, useChainId } from "~/lib/hooks";
-import { filterEligibleChains } from "~/lib/utils/chains";
+import { filterEligibleChainsForRemoteDeployment } from "~/lib/utils/chains";
 import { getNativeToken } from "~/lib/utils/getNativeToken";
 import ChainPicker from "~/ui/compounds/ChainPicker";
 import { NextButton } from "~/ui/compounds/MultiStepForm";
@@ -31,7 +31,7 @@ export const Step2: FC = () => {
 
   const { handleSubmit, isReady } = useHandleSubmit();
 
-  const eligibleChains = filterEligibleChains(state.chains, chainId);
+  const eligibleChains = filterEligibleChainsForRemoteDeployment(state.chains, chainId);
 
   const formSubmitRef = useRef<ComponentRef<"button">>(null);
 

--- a/apps/maestro/src/lib/utils/chains.ts
+++ b/apps/maestro/src/lib/utils/chains.ts
@@ -1,4 +1,3 @@
-import { CHAINS_WITHOUT_DEPLOYMENT } from "~/config/chains";
 import { NEXT_PUBLIC_WHITELISTED_DEST_CHAINS_FOR_VM } from "~/config/env";
 import { ITSChainConfig } from "~/server/chainConfig";
 
@@ -33,8 +32,6 @@ export const filterEligibleChains = (
   const isAllChainsWhitelisted = whitelistedChains[0] === "all";
 
   return destinationChains.filter((chain) => {
-    if (CHAINS_WITHOUT_DEPLOYMENT.includes(chain.chain_id))
-      return false;
     const isOriginChainSameAsDestinationChain =
       chain.chain_id === currentChainId;
     const areDifferentChainTypes = chain.chain_type !== currentChain.chain_type;

--- a/apps/maestro/src/lib/utils/chains.ts
+++ b/apps/maestro/src/lib/utils/chains.ts
@@ -1,3 +1,4 @@
+import { CHAINS_WITHOUT_DEPLOYMENT } from "~/config/chains";
 import { NEXT_PUBLIC_WHITELISTED_DEST_CHAINS_FOR_VM } from "~/config/env";
 import { ITSChainConfig } from "~/server/chainConfig";
 
@@ -8,8 +9,9 @@ type ChainConfigIndex = {
 };
 
 /**
- * Filters out destination chains that are not eligible for the current chain vm chain.
+ * Filters out destination chains that are not eligible for the current chain vm chain for ITS transfers.
  * Currently, only VM chains are eligible for the current chain type.
+ * Use filterEligibleChainsForRemoteDeployment instead to get the chains that support remote deployments 
  * @param destinationChains - The list of chains to filter.
  * @param currentChainId - The ID of the current chain.
  * @returns A filtered list of chains.
@@ -50,6 +52,16 @@ export const filterEligibleChains = (
     // Chains with the same chain type are always included
     return true;
   });
+};
+
+export const filterEligibleChainsForRemoteDeployment = (
+  destinationChains: ITSChainConfig[],
+  currentChainId: number
+): ITSChainConfig[] => {
+  const eligibleDestinationChains = filterEligibleChains(destinationChains, currentChainId);
+  return eligibleDestinationChains.filter((chain) => (
+    !CHAINS_WITHOUT_DEPLOYMENT.includes(chain.chain_id)
+  ));
 };
 
 /**

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
@@ -404,8 +404,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
     tokenAddress: props.tokenAddress,
   });
 
-  // eslint-disable-next-line prefer-const
-  let [registered, unregistered] = Maybe.of(interchainToken?.matchingTokens)
+  const [registered, unregisteredUnfiltered] = Maybe.of(interchainToken?.matchingTokens)
     .map(
       map(
         (token) =>
@@ -424,7 +423,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
 
   // There are some chains where we cannot remote deploy to
   // Thus, we need to remove these chains from the `unregistered` object.
-  unregistered = unregistered.filter((token) => !(CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId)));
+  const unregistered = unregisteredUnfiltered.filter((token) => !CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId));
 
   const destinationChainIds = useMemo(
     () =>

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
@@ -8,6 +8,7 @@ import { useSession } from "next-auth/react";
 import { concat, isEmpty, map, partition, uniq, without } from "rambda";
 
 import {
+  CHAINS_WITHOUT_DEPLOYMENT,
   EVM_CHAIN_IDS_WITH_NON_DETERMINISTIC_TOKEN_ADDRESS,
   SUI_CHAIN_ID,
 } from "~/config/chains";
@@ -403,7 +404,8 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
     tokenAddress: props.tokenAddress,
   });
 
-  const [registered, unregistered] = Maybe.of(interchainToken?.matchingTokens)
+  // eslint-disable-next-line prefer-const
+  let [registered, unregistered] = Maybe.of(interchainToken?.matchingTokens)
     .map(
       map(
         (token) =>
@@ -419,6 +421,10 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
       [[], []],
       partition((x) => x.isRegistered)
     );
+
+  // There are some chains where we cannot remote deploy to
+  // Thus, we need to remove these chains from the `unregistered` object.
+  unregistered = unregistered.filter((token) => !(CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId)));
 
   const destinationChainIds = useMemo(
     () =>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `filterEligibleChainsForRemoteDeployment` and use it across deployment steps; exclude non-deployable chains from unregistered tokens list.
> 
> - **Utils (`lib/utils/chains.ts`)**:
>   - Clarify `filterEligibleChains` for ITS transfers and stop filtering `CHAINS_WITHOUT_DEPLOYMENT` there.
>   - Add `filterEligibleChainsForRemoteDeployment` that wraps `filterEligibleChains` and filters out `CHAINS_WITHOUT_DEPLOYMENT`.
> - **Canonical/Interchain Deployment Steps**:
>   - Replace `filterEligibleChains` with `filterEligibleChainsForRemoteDeployment` in `.../CanonicalTokenDeployment/.../DeployAndRegister.tsx` and `.../InterchainTokenDeployment/.../DeployAndRegister.tsx`.
> - **Interchain Token Details Page**:
>   - Filter `unregistered` tokens to exclude chains in `CHAINS_WITHOUT_DEPLOYMENT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07d3c5b71ce06b918a44123703bdb50db2c10076. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->