### PR TITLE
Fix: xrpl remote deployment (2) ITS-135

### DIFF
--- a/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/CanonicalTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -25,7 +25,7 @@ import { RegisterCanonicalTokenResult } from "~/features/suiHooks/useRegisterCan
 import { useTransactionsContainer } from "~/features/Transactions";
 import { useBalance, useChainId } from "~/lib/hooks";
 import { handleTransactionResult } from "~/lib/transactions/handlers";
-import { filterEligibleChains } from "~/lib/utils/chains";
+import { filterEligibleChainsForRemoteDeployment } from "~/lib/utils/chains";
 import { getNativeToken } from "~/lib/utils/getNativeToken";
 import ChainPicker from "~/ui/compounds/ChainPicker";
 import { NextButton, TokenNameAlert } from "~/ui/compounds/MultiStepForm";
@@ -258,7 +258,7 @@ export const Step3: FC = () => {
     ]
   );
 
-  const eligibleChains = filterEligibleChains(state.chains, chainId);
+  const eligibleChains = filterEligibleChainsForRemoteDeployment(state.chains, chainId);
 
   const formSubmitRef = useRef<ComponentRef<"button">>(null);
 

--- a/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
+++ b/apps/maestro/src/features/InterchainTokenDeployment/steps/deploy-and-register/DeployAndRegister.tsx
@@ -4,7 +4,7 @@ import { ComponentRef, useMemo, useRef, type FC } from "react";
 import { parseUnits } from "viem";
 
 import { useBalance, useChainId } from "~/lib/hooks";
-import { filterEligibleChains } from "~/lib/utils/chains";
+import { filterEligibleChainsForRemoteDeployment } from "~/lib/utils/chains";
 import { getNativeToken } from "~/lib/utils/getNativeToken";
 import ChainPicker from "~/ui/compounds/ChainPicker";
 import { NextButton } from "~/ui/compounds/MultiStepForm";
@@ -31,7 +31,7 @@ export const Step2: FC = () => {
 
   const { handleSubmit, isReady } = useHandleSubmit();
 
-  const eligibleChains = filterEligibleChains(state.chains, chainId);
+  const eligibleChains = filterEligibleChainsForRemoteDeployment(state.chains, chainId);
 
   const formSubmitRef = useRef<ComponentRef<"button">>(null);
 

--- a/apps/maestro/src/lib/utils/chains.ts
+++ b/apps/maestro/src/lib/utils/chains.ts
@@ -1,3 +1,4 @@
+import { CHAINS_WITHOUT_DEPLOYMENT } from "~/config/chains";
 import { NEXT_PUBLIC_WHITELISTED_DEST_CHAINS_FOR_VM } from "~/config/env";
 import { ITSChainConfig } from "~/server/chainConfig";
 
@@ -8,8 +9,9 @@ type ChainConfigIndex = {
 };
 
 /**
- * Filters out destination chains that are not eligible for the current chain vm chain.
+ * Filters out destination chains that are not eligible for the current chain vm chain for ITS transfers.
  * Currently, only VM chains are eligible for the current chain type.
+ * Use filterEligibleChainsForRemoteDeployment instead to get the chains that support remote deployments 
  * @param destinationChains - The list of chains to filter.
  * @param currentChainId - The ID of the current chain.
  * @returns A filtered list of chains.
@@ -50,6 +52,16 @@ export const filterEligibleChains = (
     // Chains with the same chain type are always included
     return true;
   });
+};
+
+export const filterEligibleChainsForRemoteDeployment = (
+  destinationChains: ITSChainConfig[],
+  currentChainId: number
+): ITSChainConfig[] => {
+  const eligibleDestinationChains = filterEligibleChains(destinationChains, currentChainId);
+  return eligibleDestinationChains.filter((chain) => (
+    !CHAINS_WITHOUT_DEPLOYMENT.includes(chain.chain_id)
+  ));
 };
 
 /**

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
@@ -404,8 +404,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
     tokenAddress: props.tokenAddress,
   });
 
-  // eslint-disable-next-line prefer-const
-  let [registered, unregistered] = Maybe.of(interchainToken?.matchingTokens)
+  const [registered, unregisteredUnfiltered] = Maybe.of(interchainToken?.matchingTokens)
     .map(
       map(
         (token) =>
@@ -424,7 +423,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
 
   // There are some chains where we cannot remote deploy to
   // Thus, we need to remove these chains from the `unregistered` object.
-  unregistered = unregistered.filter((token) => !(CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId)));
+  const unregistered = unregisteredUnfiltered.filter((token) => !(CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId)));
 
   const destinationChainIds = useMemo(
     () =>

--- a/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
+++ b/apps/maestro/src/ui/pages/InterchainTokenDetailsPage/ConnectedInterchainTokensPage.tsx
@@ -423,7 +423,7 @@ const ConnectedInterchainTokensPage: FC<ConnectedInterchainTokensPageProps> = (
 
   // There are some chains where we cannot remote deploy to
   // Thus, we need to remove these chains from the `unregistered` object.
-  const unregistered = unregisteredUnfiltered.filter((token) => !(CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId)));
+  const unregistered = unregisteredUnfiltered.filter((token) => !CHAINS_WITHOUT_DEPLOYMENT.includes(token.chainId));
 
   const destinationChainIds = useMemo(
     () =>


### PR DESCRIPTION
# Summary
The previous PR #709 incorrectly allowed users to make remote deployments to XRPL. This is fixed in this PR, i.e., the user should never see the option to make a remote deployment to XRPL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out chains without remote deployment support (e.g., XRPL) from eligible destinations across deployment flows and token details.
> 
> - **Utils**:
>   - Add `filterEligibleChainsForRemoteDeployment` in `lib/utils/chains.ts` to filter `CHAINS_WITHOUT_DEPLOYMENT` after `filterEligibleChains`.
> - **Deployment Flows**:
>   - Replace `filterEligibleChains` with `filterEligibleChainsForRemoteDeployment` in `CanonicalTokenDeployment/.../DeployAndRegister.tsx` and `InterchainTokenDeployment/.../DeployAndRegister.tsx` to hide non-deployable chains from `ChainPicker`.
> - **Interchain Token Details**:
>   - Filter `unregistered` tokens by `CHAINS_WITHOUT_DEPLOYMENT` in `ConnectedInterchainTokensPage.tsx` to prevent showing unsupported chains.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0b218341f953319295027713771a8cf00d564af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->