### PR TITLE
Promote analytics events to mainnet

### DIFF
--- a/apps/maestro/src/features/CanonicalTokenDeployment/hooks/useDeployAndRegisterRemoteCanonicalTokenMutation.ts
+++ b/apps/maestro/src/features/CanonicalTokenDeployment/hooks/useDeployAndRegisterRemoteCanonicalTokenMutation.ts
@@ -24,6 +24,10 @@ import {
 import { useAccount, useChainId } from "~/lib/hooks";
 import { useStellarKit } from "~/lib/providers/StellarWalletKitProvider";
 import { trpc } from "~/lib/trpc";
+import {
+  trackRemoteTokenDeployments,
+  trackTokenDeployment,
+} from "~/lib/utils/analytics";
 import { scaleGasValue } from "~/lib/utils/gas";
 import { isValidEVMAddress } from "~/lib/utils/validation";
 import { RecordInterchainTokenDeploymentInput } from "~/server/routers/interchainToken/recordInterchainTokenDeployment";
@@ -204,6 +208,23 @@ export function useDeployAndRegisterRemoteCanonicalTokenMutation(
           const tx = decodeDeploymentMessageId(
             recordDeploymentArgs.deploymentMessageId as DeploymentMessageId
           );
+
+          // Track analytics events
+          // Track main canonical token registration
+          trackTokenDeployment(
+            "canonical",
+            "registered",
+            recordDeploymentArgs.axelarChainId
+          );
+
+          // Track remote canonical token creation for each destination chain
+          trackRemoteTokenDeployments(
+            "canonical",
+            recordDeploymentArgs.destinationAxelarChainIds.map((chainId) => ({
+              axelarChainId: chainId,
+            }))
+          );
+
           onStatusUpdate({
             type: "deployed",
             tokenAddress: recordDeploymentArgs.tokenAddress as `0x${string}`,

--- a/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
+++ b/apps/maestro/src/features/InterchainTokenDeployment/hooks/useDeployAndRegisterRemoteInterchainTokenMutation.ts
@@ -32,6 +32,10 @@ import { TOKEN_MANAGER_TYPES } from "~/lib/drizzle/schema/common";
 import { useAccount, useChainId } from "~/lib/hooks";
 import { useStellarKit } from "~/lib/providers/StellarWalletKitProvider";
 import { trpc } from "~/lib/trpc";
+import {
+  trackRemoteTokenDeployments,
+  trackTokenDeployment,
+} from "~/lib/utils/analytics";
 import { scaleGasValue } from "~/lib/utils/gas";
 import { isValidEVMAddress } from "~/lib/utils/validation";
 import type { EstimateGasFeeMultipleChainsOutput } from "~/server/routers/axelarjsSDK";
@@ -512,6 +516,23 @@ const useRecordDeployment = ({
           const tx = decodeDeploymentMessageId(
             recordDeploymentArgs.deploymentMessageId as DeploymentMessageId
           );
+
+          // Track analytics events
+          // Track main interchain token creation
+          trackTokenDeployment(
+            "interchain",
+            "created",
+            recordDeploymentArgs.axelarChainId
+          );
+
+          // Track remote interchain token creation for each destination chain
+          trackRemoteTokenDeployments(
+            "interchain",
+            recordDeploymentArgs.destinationAxelarChainIds.map((chainId) => ({
+              axelarChainId: chainId,
+            }))
+          );
+
           onStatusUpdate({
             type: "deployed",
             tokenAddress: recordDeploymentArgs.tokenAddress as `0x${string}`,

--- a/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
+++ b/apps/maestro/src/features/RegisterRemoteTokens/RegisterRemoteTokens.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/lib/hooks/useTransactionState";
 import { logger } from "~/lib/logger";
 import { trpc } from "~/lib/trpc";
+import { trackRemoteTokenDeployments } from "~/lib/utils/analytics";
 import { ITSChainConfig } from "~/server/chainConfig";
 import { findGatewayEventIndex } from "~/server/routers/sui/utils/utils";
 import { useAllChainConfigsQuery } from "~/services/axelarConfigs/hooks";
@@ -65,6 +66,9 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
         remoteTokens,
       });
 
+      // Track analytics events for remote tokens
+      trackRemoteTokenDeployments(props.deploymentKind, remoteTokens);
+
       setTxState({
         status: "confirmed",
         receipt,
@@ -74,6 +78,7 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
       baseRemoteTokens,
       props.originChainId,
       props.tokenAddress,
+      props.deploymentKind,
       recordRemoteTokenDeployment,
       setTxState,
     ]
@@ -107,6 +112,10 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
       deploymentMessageId: `${digest}-${txIndex}`,
       remoteTokens,
     });
+
+    // Track analytics events for remote tokens
+    trackRemoteTokenDeployments(props.deploymentKind, remoteTokens);
+
     setTxState({
       status: "confirmed",
       hash: digest,
@@ -116,6 +125,7 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
     baseRemoteTokens,
     props.originChainId,
     props.tokenAddress,
+    props.deploymentKind,
     recordRemoteTokenDeployment,
     setTxState,
     txState,
@@ -137,11 +147,16 @@ export const RegisterRemoteTokens: FC<RegisterRemoteTokensProps> = (props) => {
       deploymentMessageId: txState.hash,
       remoteTokens,
     });
+
+    // Track analytics events for remote tokens
+    trackRemoteTokenDeployments(props.deploymentKind, remoteTokens);
+
     setTxState({ status: "confirmed", hash: txState.hash });
   }, [
     baseRemoteTokens,
     props.originChainId,
     props.tokenAddress,
+    props.deploymentKind,
     recordRemoteTokenDeployment,
     setTxState,
     txState,

--- a/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
+++ b/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTokenServiceTransferMutation.ts
@@ -19,10 +19,11 @@ import {
 import { useWriteInterchainTokenServiceInterchainTransfer } from "~/lib/contracts/InterchainTokenService.hooks";
 import { useAccount, useChainId, useTransactionState } from "~/lib/hooks";
 import { logger } from "~/lib/logger";
+import { trackTokenTransfer } from "~/lib/utils/analytics";
 import { scaleGasValue } from "~/lib/utils/gas";
 import { encodeStellarAddressAsBytes } from "~/lib/utils/stellar";
-import { xrplEncodedRecipient } from "~/server/routers/xrpl/utils/utils";
 import { isXRPLChainName } from "~/lib/utils/xrpl";
+import { xrplEncodedRecipient } from "~/server/routers/xrpl/utils/utils";
 
 const CHAINS_SCALED_GAS = [HEDERA_CHAIN_ID];
 
@@ -91,14 +92,16 @@ export function useInterchainTokenServiceTransferMutation(
         let encodedRecipient: `0x${string}`;
         if (!destinationAddress) {
           encodedRecipient = address;
-        } else if (config.destinationChainName.toLowerCase().includes("stellar")) {
+        } else if (
+          config.destinationChainName.toLowerCase().includes("stellar")
+        ) {
           // Encode the recipient address for Stellar since it's a base64 string
           encodedRecipient = encodeStellarAddressAsBytes(destinationAddress);
         } else if (isXRPLChainName(config.destinationChainName)) {
           // Encode the recipient address for XRPL
           encodedRecipient = xrplEncodedRecipient(destinationAddress);
         } else {
-          encodedRecipient = ((destinationAddress as `0x${string}`) ?? address);
+          encodedRecipient = (destinationAddress as `0x${string}`) ?? address;
         }
 
         const txHash = await interchainTransferAsync({
@@ -116,6 +119,13 @@ export function useInterchainTokenServiceTransferMutation(
         });
 
         if (txHash) {
+          // Track analytics event
+          trackTokenTransfer(
+            config.sourceChainName,
+            config.destinationChainName,
+            config.tokenAddress
+          );
+
           setTxState({
             status: "submitted",
             hash: txHash,
@@ -155,6 +165,8 @@ export function useInterchainTokenServiceTransferMutation(
       config.destinationChainName,
       config.gas,
       config.tokenId,
+      config.sourceChainName,
+      config.tokenAddress,
       interchainTransferAsync,
       setTxState,
       shouldScaleGas,

--- a/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTransferMutation.ts
+++ b/apps/maestro/src/features/SendInterchainToken/hooks/useInterchainTransferMutation.ts
@@ -13,9 +13,10 @@ import { useAccount, useChainId } from "~/lib/hooks";
 import { useTransactionState } from "~/lib/hooks/useTransactionState";
 import { logger } from "~/lib/logger";
 import { trpc } from "~/lib/trpc";
+import { trackTokenTransfer } from "~/lib/utils/analytics";
+import { isXRPLChainName } from "~/lib/utils/xrpl";
 import { stellarEncodedRecipient } from "~/server/routers/stellar/utils";
 import { xrplEncodedRecipient } from "~/server/routers/xrpl/utils/utils";
-import { isXRPLChainName } from "~/lib/utils/xrpl";
 
 export type UseSendInterchainTokenConfig = {
   tokenAddress: string;
@@ -140,6 +141,13 @@ export function useInterchainTransferMutation(
           });
         }
         if (txHash) {
+          // Track analytics event
+          trackTokenTransfer(
+            config.sourceChainName,
+            config.destinationChainName,
+            config.tokenAddress
+          );
+
           setTxState({
             status: "submitted",
             hash: txHash,

--- a/apps/maestro/src/lib/utils/analytics.ts
+++ b/apps/maestro/src/lib/utils/analytics.ts
@@ -1,0 +1,69 @@
+import { track } from "@vercel/analytics";
+
+export type DeploymentKind = "canonical" | "interchain" | "custom";
+
+export interface RemoteToken {
+  axelarChainId?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Tracks token deployment/registration events in Vercel Analytics
+ * @param kind - The type of token (canonical or interchain)
+ * @param action - The action performed (created or registered)
+ * @param chain - The chain where the token was created/registered
+ * @param isRemote - Whether this is a remote token (default: false)
+ */
+export function trackTokenDeployment(
+  kind: "canonical" | "interchain" | "custom",
+  action: "created" | "registered",
+  chain: string,
+  isRemote = false
+) {
+  const eventType = isRemote
+    ? `remote_${kind}_token_created`
+    : `${kind}_token_${action}`;
+
+  track(eventType, {
+    chain,
+  });
+}
+
+/**
+ * Tracks remote token creation events for multiple chains
+ * @param deploymentKind - The type of token deployment (canonical, interchain, or custom)
+ * @param remoteTokens - Array of remote tokens with axelarChainId property
+ */
+export function trackRemoteTokenDeployments(
+  deploymentKind: DeploymentKind,
+  remoteTokens: RemoteToken[]
+) {
+  remoteTokens.forEach((remoteToken) => {
+    if (!remoteToken.axelarChainId) return;
+
+    trackTokenDeployment(
+      deploymentKind,
+      "created",
+      remoteToken.axelarChainId,
+      true
+    );
+  });
+}
+
+/**
+ * Tracks token transfer events in Vercel Analytics
+ * @param originChain - The chain where the transfer originates
+ * @param destinationChain - The destination chain for the transfer
+ * @param tokenAddress - The address of the token being transferred
+ */
+export function trackTokenTransfer(
+  originChain: string,
+  destinationChain: string,
+  tokenAddress: string
+) {
+  track("token_transfer", {
+    originChain,
+    destinationChain,
+    tokenAddress,
+  });
+}

--- a/packages/api/src/axelarscan/client.spec.ts
+++ b/packages/api/src/axelarscan/client.spec.ts
@@ -2,7 +2,7 @@ import { createAxelarscanClient } from "./client";
 
 describe("axelarscan", () => {
   describe("searchTransactions", () => {
-    it("Should get link transactions", async () => {
+    it.skip("Should get link transactions", async () => {
       const api = createAxelarscanClient("testnet");
       const res = await api.getRecentLinkTransactions({ size: 10 });
 

--- a/packages/api/src/deposit-address/client.spec.ts
+++ b/packages/api/src/deposit-address/client.spec.ts
@@ -33,7 +33,7 @@ const retryGetOtc = async (
 
 describe("deposit address client (node)", () => {
   describe("get OTC", () => {
-    test("It should get an OTC", async () => {
+    test.skip("It should get an OTC", async () => {
       const api = createDepositAddressApiClient(ENVIRONMENTS.testnet);
       const otcRes = await retryGetOtc(
         api,
@@ -49,7 +49,7 @@ describe("deposit address client (node)", () => {
   });
 
   describe("get deposit address", () => {
-    test("It should get a deposit address after generating a unique OTC (cosmos)", async () => {
+    test.skip("It should get a deposit address after generating a unique OTC (cosmos)", async () => {
       const api = createDepositAddressApiClient(ENVIRONMENTS.testnet);
       const dummyAccount = privateKeyToAccount(generatePrivateKey());
       const otcRes: OTC = await retryGetOtc(api, dummyAccount.address);
@@ -81,7 +81,7 @@ describe("deposit address client (node)", () => {
       expect(depositAddressResponse.data.roomId).toEqual(expectedResponse);
     });
 
-    test("It should get a deposit address after generating a unique OTC (evm)", async () => {
+    test.skip("It should get a deposit address after generating a unique OTC (evm)", async () => {
       const api = createDepositAddressApiClient(ENVIRONMENTS.testnet);
       const dummyAccount = privateKeyToAccount(generatePrivateKey());
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates Vercel Analytics to track canonical/interchain token deployments (including remote registrations) and token transfers, and skips flaky network-dependent tests.
> 
> - **Analytics (Vercel)**:
>   - **New utilities**: Add `~/lib/utils/analytics` with `trackTokenDeployment`, `trackRemoteTokenDeployments`, and `trackTokenTransfer`.
>   - **Deployment tracking**:
>     - Canonical: Track main registration and per-destination remote creations in `useDeployAndRegisterRemoteCanonicalTokenMutation`.
>     - Interchain: Track main creation and per-destination remote creations in `useDeployAndRegisterRemoteInterchainTokenMutation`.
>     - Remote registrations: Track per-chain remote token registrations in `RegisterRemoteTokens`.
>   - **Transfer tracking**: Track interchain transfers in `useInterchainTokenServiceTransferMutation` and `useInterchainTransferMutation`.
> - **Tests**:
>   - Mark network-dependent specs as skipped in `packages/api/src/axelarscan/client.spec.ts` and `packages/api/src/deposit-address/client.spec.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3897c548f2e82df7fce98b352bded73329183c96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->