### PR TITLE
OCSI-1 chore: update monad testnet chain name

### DIFF
--- a/apps/maestro/src/config/chains/evm-chains.ts
+++ b/apps/maestro/src/config/chains/evm-chains.ts
@@ -616,10 +616,10 @@ export const EVM_CHAINS: ExtendedWagmiChainConfig[] = [
       monadTestnet,
       ENVIRONMENTS.testnet,
       [],
-      "monad"
+      "monad-3"
     ),
-    axelarChainId: "monad",
-    axelarChainName: "monad",
+    axelarChainId: "monad-3",
+    axelarChainName: "monad-3",
     supportWagmi: true,
     environment: ENVIRONMENTS.testnet,
   },

--- a/packages/evm/src/clients/testnet-client.ts
+++ b/packages/evm/src/clients/testnet-client.ts
@@ -48,7 +48,7 @@ export const TESTNET_CHAINS = {
   "filecoin-2": filecoinCalibration,
   "linea-sepolia": lineaSepolia,
   "mantle-sepolia": mantleTestnet,
-  monad: monadTestnet,
+  "monad-3": monadTestnet,
   "optimism-sepolia": optimismSepolia,
   immutable: immutableZkEvmTestnet,
   linea: lineaTestnet,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns Monad testnet naming with `monad-3`.
> 
> - In `evm-chains.ts`, updates `monadTestnet` config: `rpcUrls` chain key changed to `"monad-3"`, and sets `axelarChainId`/`axelarChainName` to `"monad-3"`
> - In `testnet-client.ts`, updates `TESTNET_CHAINS` mapping key from `"monad"` to `"monad-3"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ac8edbe5e37f477ff9dcfa590fac010d2ea8b59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->